### PR TITLE
[MODEXPS-42] - Improving the extensibility of the Job execution service

### DIFF
--- a/src/main/java/org/folio/des/builder/job/BulkEditQueryJobCommandBuilder.java
+++ b/src/main/java/org/folio/des/builder/job/BulkEditQueryJobCommandBuilder.java
@@ -1,0 +1,25 @@
+package org.folio.des.builder.job;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.folio.de.entity.Job;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class BulkEditQueryJobCommandBuilder implements JobCommandBuilder {
+  @Override
+  public JobParameters buildJobCommand(Job job) {
+    Map<String, JobParameter> params = new HashMap<>();
+    params.put("entityType", new JobParameter(job.getEntityType().getValue()));
+    params.put("query", new JobParameter(job.getExportTypeSpecificParameters().getQuery()));
+    return new JobParameters(params);
+  }
+}

--- a/src/main/java/org/folio/des/builder/job/BurSarFeeFinesJobCommandBuilder.java
+++ b/src/main/java/org/folio/des/builder/job/BurSarFeeFinesJobCommandBuilder.java
@@ -1,0 +1,34 @@
+package org.folio.des.builder.job;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.folio.de.entity.Job;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class BurSarFeeFinesJobCommandBuilder implements JobCommandBuilder {
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public JobParameters buildJobCommand(Job job) {
+    Map<String, JobParameter> params = new HashMap<>();
+    try {
+      params.put("bursarFeeFines",
+        new JobParameter(objectMapper.writeValueAsString(job.getExportTypeSpecificParameters().getBursarFeeFines())));
+      return new JobParameters(params);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/src/main/java/org/folio/des/builder/job/CirculationLogJobCommandBuilder.java
+++ b/src/main/java/org/folio/des/builder/job/CirculationLogJobCommandBuilder.java
@@ -1,0 +1,24 @@
+package org.folio.des.builder.job;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.folio.de.entity.Job;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class CirculationLogJobCommandBuilder implements JobCommandBuilder {
+  @Override
+  public JobParameters buildJobCommand(Job job) {
+    Map<String, JobParameter> params = new HashMap<>();
+    params.put("query", new JobParameter(job.getExportTypeSpecificParameters().getQuery()));
+    return new JobParameters(params);
+  }
+}

--- a/src/main/java/org/folio/des/builder/job/JobCommandBuilder.java
+++ b/src/main/java/org/folio/des/builder/job/JobCommandBuilder.java
@@ -1,0 +1,9 @@
+package org.folio.des.builder.job;
+
+import org.folio.de.entity.Job;
+import org.springframework.batch.core.JobParameters;
+
+@FunctionalInterface
+public interface JobCommandBuilder {
+  JobParameters buildJobCommand(Job job);
+}

--- a/src/main/java/org/folio/des/builder/job/JobCommandBuilderResolver.java
+++ b/src/main/java/org/folio/des/builder/job/JobCommandBuilderResolver.java
@@ -1,0 +1,19 @@
+package org.folio.des.builder.job;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.folio.des.domain.dto.ExportType;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@RequiredArgsConstructor
+@Log4j2
+public class JobCommandBuilderResolver {
+  private final Map<ExportType, JobCommandBuilder> converters;
+
+  public Optional<JobCommandBuilder> resolve(ExportType type) {
+    return Optional.ofNullable(converters.get(type));
+  }
+}

--- a/src/main/java/org/folio/des/config/ServiceConfiguration.java
+++ b/src/main/java/org/folio/des/config/ServiceConfiguration.java
@@ -3,6 +3,11 @@ package org.folio.des.config;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.folio.des.builder.job.BulkEditQueryJobCommandBuilder;
+import org.folio.des.builder.job.BurSarFeeFinesJobCommandBuilder;
+import org.folio.des.builder.job.CirculationLogJobCommandBuilder;
+import org.folio.des.builder.job.JobCommandBuilder;
+import org.folio.des.builder.job.JobCommandBuilderResolver;
 import org.folio.des.client.ConfigurationClient;
 import org.folio.des.converter.DefaultExportConfigToModelConfigConverter;
 import org.folio.des.converter.DefaultModelConfigToExportConfigConverter;
@@ -82,6 +87,16 @@ public class ServiceConfiguration {
     exportConfigServiceMap.put(ExportType.BURSAR_FEES_FINES, burSarFeesFinesExportConfigService);
     exportConfigServiceMap.put(ExportType.EDIFACT_ORDERS_EXPORT, baseExportConfigService);
     return new ExportConfigServiceResolver(exportConfigServiceMap);
+  }
+
+  @Bean JobCommandBuilderResolver jobCommandBuilderResolver(BulkEditQueryJobCommandBuilder bulkEditQueryJobCommandBuilder,
+    BurSarFeeFinesJobCommandBuilder burSarFeeFinesJobCommandBuilder,
+    CirculationLogJobCommandBuilder circulationLogJobCommandBuilder) {
+    Map<ExportType, JobCommandBuilder> converters = new HashMap<>();
+    converters.put(ExportType.BULK_EDIT_QUERY, bulkEditQueryJobCommandBuilder);
+    converters.put(ExportType.BURSAR_FEES_FINES, burSarFeeFinesJobCommandBuilder);
+    converters.put(ExportType.CIRCULATION_LOG, circulationLogJobCommandBuilder);
+    return new JobCommandBuilderResolver(converters);
   }
 
 }

--- a/src/main/java/org/folio/des/scheduling/RefreshConfigAspect.java
+++ b/src/main/java/org/folio/des/scheduling/RefreshConfigAspect.java
@@ -1,25 +1,35 @@
 package org.folio.des.scheduling;
 
-import lombok.RequiredArgsConstructor;
+import static org.folio.des.domain.dto.ExportType.BURSAR_FEES_FINES;
+
+import java.util.EnumSet;
+
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
 import org.folio.des.domain.dto.ExportConfig;
+import org.folio.des.domain.dto.ExportType;
 import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
 
 @Aspect
 @Component
 @RequiredArgsConstructor
 public class RefreshConfigAspect {
-
+  private final EnumSet<ExportType> applyAspectExportTypes = EnumSet.of(BURSAR_FEES_FINES);
   private final ExportScheduler scheduler;
 
   @After("(execution(* org.folio.des.service.config.ExportConfigService.updateConfig(..)) && args(..,config))")
   public void refreshAfterUpdate(ExportConfig config) {
-    scheduler.updateTasks(config);
+    if (applyAspectExportTypes.contains(config.getType())) {
+      scheduler.updateTasks(config);
+    }
   }
 
   @After("(execution(* org.folio.des.service.config.ExportConfigService.postConfig(..)) && args(config))")
   public void refreshAfterPost(ExportConfig config) {
-    scheduler.updateTasks(config);
+    if (applyAspectExportTypes.contains(config.getType())) {
+      scheduler.updateTasks(config);
+    }
   }
 }

--- a/src/main/java/org/folio/des/service/impl/JobServiceImpl.java
+++ b/src/main/java/org/folio/des/service/impl/JobServiceImpl.java
@@ -52,6 +52,7 @@ public class JobServiceImpl implements JobService {
   static {
     OUTPUT_FORMATS.put(ExportType.BURSAR_FEES_FINES, "Fees & Fines Bursar Report");
     OUTPUT_FORMATS.put(ExportType.CIRCULATION_LOG, "Comma-Separated Values (CSV)");
+    OUTPUT_FORMATS.put(ExportType.EDIFACT_ORDERS_EXPORT, "EDIFACT orders export (EDI)");
   }
 
   private final JobExecutionService jobExecutionService;

--- a/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
+++ b/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
@@ -1,0 +1,47 @@
+package org.folio.des.builder.job;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.folio.des.client.ConfigurationClient;
+import org.folio.des.config.JacksonConfiguration;
+import org.folio.des.config.ServiceConfiguration;
+import org.folio.des.domain.dto.ExportType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(classes = {JacksonConfiguration.class, ServiceConfiguration.class})
+class JobCommandBuilderResolverTest {
+
+  @Autowired
+  private JobCommandBuilderResolver resolver;
+  @MockBean
+  private ConfigurationClient client;
+
+  @ParameterizedTest
+  @DisplayName("Should retrieve builder for specific export type if builder is registered in the resolver")
+  @CsvSource({
+    "BURSAR_FEES_FINES, BurSarFeeFinesJobCommandBuilder",
+    "CIRCULATION_LOG, CirculationLogJobCommandBuilder",
+    "BULK_EDIT_QUERY, BulkEditQueryJobCommandBuilder"
+  })
+  void shouldRetrieveBuilderForSpecifiedExportTypeIfBuilderIsRegisteredInTheResolver(ExportType exportType,
+              String expBuilderClass) {
+    Optional<JobCommandBuilder> builder = resolver.resolve(exportType);
+    assertEquals(expBuilderClass, builder.get().getClass().getSimpleName());
+  }
+
+  @Test
+  @DisplayName("Should not retrieve builder for specific export type if builder is not registered in the resolver")
+  void shouldRetrieveBuilderForSpecifiedExportTypeIfBuilderIsRegisteredInTheResolver() {
+    Optional<JobCommandBuilder> builder = resolver.resolve(ExportType.EDIFACT_ORDERS_EXPORT);
+    assertTrue(builder.isEmpty());
+  }
+}

--- a/src/test/java/org/folio/des/converter/acquisition/EdifactExportConfigToModelConfigConverterTest.java
+++ b/src/test/java/org/folio/des/converter/acquisition/EdifactExportConfigToModelConfigConverterTest.java
@@ -1,8 +1,6 @@
 package org.folio.des.converter.acquisition;
 
 import static org.folio.des.service.config.ExportConfigConstants.DEFAULT_MODULE_NAME;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 


### PR DESCRIPTION
## Purpose

**mod-data-export-spring is core module** for implementing scheduling export jobs across FOLIO project and it should be easy to extensible for different types of export.

For now to add logic which build JobCommand should be done in the separate builders for each ExportType and implement interface **org.folio.des.builder.job.JobCommandBuilder**

## Approach
**Refactoring**
1. org.folio.des.service.JobExecutionService : Updated logic of JobCommand building 
1.1 org.folio.des.builder.job.BulkEditQueryJobCommandBuilder for BULK_EDIT_QUERY
1.2 org.folio.des.builder.job.BurSarFeeFinesJobCommandBuilder for  BURSAR_FEES_FINES
1.3 org.folio.des.builder.job.CirculationLogJobCommandBuilder for CIRCULATION_LOG

**Logic**
org.folio.des.scheduling.RefreshConfigAspect now run update schedule only for BURSAR_FEES_FINES.


## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
