### PR TITLE
MODEXPS-59 - Fix several tenants usage errors for data export process

### DIFF
--- a/src/main/java/org/folio/des/config/kafka/KafkaService.java
+++ b/src/main/java/org/folio/des/config/kafka/KafkaService.java
@@ -98,6 +98,6 @@ public class KafkaService {
       throw new IllegalStateException("Can't send to Kafka because tenant is blank");
     }
     kafkaTemplate.send(getTenantTopicName(topic.getTopicName(), tenant), key, data);
-    log.info("Sent {}.", data);
+    log.info("Sent {} with tenant {}.", data, tenant);
   }
 }

--- a/src/main/java/org/folio/des/service/impl/JobServiceImpl.java
+++ b/src/main/java/org/folio/des/service/impl/JobServiceImpl.java
@@ -147,6 +147,7 @@ public class JobServiceImpl implements JobService {
     // Send jobCommand to Kafka only after current transaction is committed, otherwise KafkaListener
     // may not find the job by id.
     registerSynchronization(new TransactionSynchronization() {
+      @Override
       public void afterCommit() {
         jobExecutionService.sendJobCommand(jobCommand);
       }


### PR DESCRIPTION
[MODEXPS-59](https://issues.folio.org/browse/MODEXPS-59) - Fix several tenants usage errors for data export process

## Purpose
From time to time scheduled job gets stuck in SCHEDULED status and never ends. In this case the specific error appears in the log that job with given id not found. 

## Approach
Sometimes Kafka service works faster than JPA repository and methods like findById may return nothing right after the save method. To avoid such situations, send job command to Kafka service only after job is fully inserted to the database, i.e. when transaction is committed.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
