### PR TITLE
MODEXPS-79 - Update folio-export-common schemas

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -6,4 +6,5 @@
   <include file="changes/create-db.xml" relativeToChangelogFile="true"/>
   <include file="changes/change-input-job-parameters.xml" relativeToChangelogFile="true"/>
   <include file="changes/db.changelog-1.3.0.xml" relativeToChangelogFile="true"/>
+  <include file="changes/db.changelog-1.4.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -1,0 +1,17 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="MODEXPS-79@@update schemas" author="siarhei_charniak">
+    <sql dbms="postgresql">
+      ALTER TYPE IdentifierType ADD VALUE 'HRID';
+      ALTER TYPE IdentifierType ADD VALUE 'FORMER_IDS';
+      ALTER TYPE IdentifierType ADD VALUE 'ACCESSION_NUMBER';
+      ALTER TYPE IdentifierType ADD VALUE 'HOLDINGS_RECORD_ID';
+      ALTER TYPE EntityType ADD VALUE 'ITEM';
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/swagger.api/jobs.yaml
+++ b/src/main/resources/swagger.api/jobs.yaml
@@ -139,9 +139,9 @@ components:
     errors:
       $ref: '../../../../folio-export-common/schemas/common/errors.json#/Errors'
     identifierType:
-      $ref: '../../../../folio-export-common/schemas/identifierType.json#/IdentifierType'
+      $ref: '../../../../folio-export-common/schemas/bulk-edit/identifierType.json#/IdentifierType'
     entityType:
-      $ref: '../../../../folio-export-common/schemas/entityType.json#/EntityType'
+      $ref: '../../../../folio-export-common/schemas/bulk-edit/entityType.json#/EntityType'
     progress:
       $ref: '../../../../folio-export-common/schemas/progress.json#/Progress'
     UUID:

--- a/src/test/java/org/folio/des/controller/JobsControllerTest.java
+++ b/src/test/java/org/folio/des/controller/JobsControllerTest.java
@@ -47,9 +47,6 @@ class JobsControllerTest extends BaseTest {
   private static final String BULK_EDIT_IDENTIFIERS_REQUEST_NO_ENTITY =
     "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"identifierType\" : \"ID\"}";
 
-  private static final String BULK_EDIT_IDENTIFIERS_REQUEST_WITH_IDENTIFIERS_WITH_ENTITY =
-    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"USER\", \"identifierType\" : \"ID\"}";
-
   private static final String BULK_EDIT_QUERY_REQUEST_NO_ENTITY_NO_QUERY =
     "{ \"type\": \"BULK_EDIT_QUERY\", \"exportTypeSpecificParameters\" : {}}";
 
@@ -309,15 +306,24 @@ class JobsControllerTest extends BaseTest {
           status().isBadRequest()));
   }
 
-  @Test
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"USER\", \"identifierType\" : \"BARCODE\"}",
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"ITEM\", \"identifierType\" : \"ID\"}",
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"ITEM\", \"identifierType\" : \"BARCODE\"}",
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"ITEM\", \"identifierType\" : \"HRID\"}",
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"ITEM\", \"identifierType\" : \"FORMER_IDS\"}",
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"ITEM\", \"identifierType\" : \"ACCESSION_NUMBER\"}",
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"ITEM\", \"identifierType\" : \"HOLDINGS_RECORD_ID\"}"
+  })
   @DisplayName("Start new bulk edit identifiers job with identifiers and entity type, should be 201")
-  void postBulkEditIdentifiersJobWithIdentifiersAndEntityType() throws Exception {
+  void postBulkEditIdentifiersJobWithIdentifiersAndEntityType(String contentString) throws Exception {
     mockMvc
       .perform(
         post("/data-export-spring/jobs")
           .contentType(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders())
-          .content(BULK_EDIT_IDENTIFIERS_REQUEST_WITH_IDENTIFIERS_WITH_ENTITY))
+          .content(contentString))
       .andExpect(
         matchAll(
           status().isCreated()));


### PR DESCRIPTION
[MODEXPS-79](https://issues.folio.org/browse/MODEXPS-79) - Update folio-export-common schemas

## Purpose
Update folio-export-common submodule to support new entityType and identifierType values

## Approach
* Updated schemas
* Updated DB
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
