### PR TITLE
MODEXPS-98: Release 1.2.3: Fix permission and security issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 2022-04-14 v1.2.3
+* [MODEXPS-61](https://issues.folio.org/browse/MODEXPS-61) Adding perms.users.assign.immutable
+* [MODEXPS-67](https://issues.folio.org/browse/MODEXPS-67) Require circulation-logs
+* spring-boot-starter-parent 2.5.12, log4j 2.17.2: fixing CVE-2022-22965, CVE-2022-21724, CVE-2022-26520,
+  CVE-2020-36518, CVE-2022-23181, CVE-2022-22950, CVE-2021-45105, CVE-2021-44832
+
 ## 2022-03-04 v1.2.2
 The primary focus of this release is fixing several tenants usage errors for data export process
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -13,6 +13,10 @@
     {
       "id": "users",
       "version": "15.3"
+    },
+    {
+      "id": "circulation-logs",
+      "version": "1.2"
     }
   ],
   "provides": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -105,7 +105,9 @@
             "login.item.post",
             "perms.users.item.post",
             "perms.users.get",
-            "configuration.entries.collection.get"
+            "configuration.entries.collection.get",
+            "configuration.entries.item.post",
+            "perms.users.assign.immutable"
           ]
         },
         {

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>org.folio</groupId>
     <artifactId>mod-data-export-spring</artifactId>
     <description>Data Export Spring module</description>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.2.3</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -400,7 +400,7 @@
         <url>https://github.com/folio-org/${project.artifactId}</url>
         <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
         <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-        <tag>v1.2.0</tag>
+        <tag>v1.2.3</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <groupId>org.folio</groupId>
     <artifactId>mod-data-export-spring</artifactId>
     <description>Data Export Spring module</description>
-    <version>1.2.3</version>
+    <version>1.2.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -400,7 +400,7 @@
         <url>https://github.com/folio-org/${project.artifactId}</url>
         <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
         <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-        <tag>v1.2.3</tag>
+        <tag>v1.2.0</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.12</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -34,7 +34,7 @@
         <hibernate-types-52.version>2.10.3</hibernate-types-52.version>
         <spring-security-core.version>5.4.5</spring-security-core.version>
         <cql2pgjson.version>32.2.0</cql2pgjson.version>
-        <log4j2.version>2.16.0</log4j2.version> <!-- if less then vulnerable to CVE-2021-44228 and CVE-2021-45046-->
+        <log4j2.version>2.17.2</log4j2.version>
         <lombok.version>1.18.18</lombok.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <json.version>20200518</json.version>
@@ -53,6 +53,20 @@
         <testcontainers.version>1.15.1</testcontainers.version>
         <wiremock.version>2.27.2</wiremock.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j2.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -132,7 +146,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-web</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
No Kiwi hot fix # 3 release is planned. This mod-data-export-spring release is independent of any hot fix.

This mod-data-export-spring release is to fix the failure when using Okapi >= 4.13.0, for details see the last paragraph in https://github.com/folio-org/okapi/releases/tag/v4.13.0