### PR TITLE
MODEXPS-94 Export eHoldings: ability to create export jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
                             <generateApiDocumentation>true</generateApiDocumentation>
                             <generateModels>true</generateModels>
                             <modelsToGenerate>
-                               BursarFeeFinesTypeMapping,BursarFeeFines,EdiConfig,Edi,EdiSchedule,ScheduleParameters,EdiEmail,EdiFtp,VendorEdiOrdersExportConfig,ExportTypeSpecificParameters,ExportConfig,ExportConfigCollection
+                               BursarFeeFinesTypeMapping,BursarFeeFines,EdiConfig,Edi,EdiSchedule,ScheduleParameters,EdiEmail,EdiFtp,VendorEdiOrdersExportConfig,ExportTypeSpecificParameters,ExportConfig,ExportConfigCollection,EHoldingsExportConfig
                             </modelsToGenerate>
                             <generateModelTests>false</generateModelTests>
                             <generateSupportingFiles>true</generateSupportingFiles>

--- a/src/main/java/org/folio/des/builder/job/EHoldingsJobCommandBuilder.java
+++ b/src/main/java/org/folio/des/builder/job/EHoldingsJobCommandBuilder.java
@@ -1,0 +1,39 @@
+package org.folio.des.builder.job;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.stereotype.Service;
+
+import org.folio.de.entity.Job;
+import org.folio.des.domain.dto.EHoldingsExportConfig;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class EHoldingsJobCommandBuilder implements JobCommandBuilder {
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public JobParameters buildJobCommand(Job job) {
+    Map<String, JobParameter> params = new HashMap<>();
+    EHoldingsExportConfig eHoldingsExportConfig = job.getExportTypeSpecificParameters().geteHoldingsExportConfig();
+    try {
+      params.put("packageSearchQuery", new JobParameter(eHoldingsExportConfig.getPackageSearchQuery()));
+      params.put("titleSearchQuery", new JobParameter(eHoldingsExportConfig.getTitleSearchQuery()));
+      params.put("packageFields",
+        new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getPackageFields())));
+      params.put("titleFields",
+        new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getTitleFields())));
+      return new JobParameters(params);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/src/main/java/org/folio/des/builder/job/EHoldingsJobCommandBuilder.java
+++ b/src/main/java/org/folio/des/builder/job/EHoldingsJobCommandBuilder.java
@@ -26,6 +26,8 @@ public class EHoldingsJobCommandBuilder implements JobCommandBuilder {
     EHoldingsExportConfig eHoldingsExportConfig = job.getExportTypeSpecificParameters().geteHoldingsExportConfig();
     try {
       params.put("packageId", new JobParameter(eHoldingsExportConfig.getPackageId()));
+      params.put("packageSearchFilters", new JobParameter(eHoldingsExportConfig.getPackageSearchFilters()));
+      params.put("titleSearchFilters", new JobParameter(eHoldingsExportConfig.getTitleSearchFilters()));
       params.put("packageFields", new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getPackageFields())));
       params.put("titleFields", new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getTitleFields())));
       return new JobParameters(params);

--- a/src/main/java/org/folio/des/builder/job/EHoldingsJobCommandBuilder.java
+++ b/src/main/java/org/folio/des/builder/job/EHoldingsJobCommandBuilder.java
@@ -25,8 +25,7 @@ public class EHoldingsJobCommandBuilder implements JobCommandBuilder {
     Map<String, JobParameter> params = new HashMap<>();
     EHoldingsExportConfig eHoldingsExportConfig = job.getExportTypeSpecificParameters().geteHoldingsExportConfig();
     try {
-      params.put("packageSearchQuery", new JobParameter(eHoldingsExportConfig.getPackageSearchQuery()));
-      params.put("titleSearchQuery", new JobParameter(eHoldingsExportConfig.getTitleSearchQuery()));
+      params.put("packageId", new JobParameter(eHoldingsExportConfig.getPackageId()));
       params.put("packageFields", new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getPackageFields())));
       params.put("titleFields", new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getTitleFields())));
       return new JobParameters(params);

--- a/src/main/java/org/folio/des/builder/job/EHoldingsJobCommandBuilder.java
+++ b/src/main/java/org/folio/des/builder/job/EHoldingsJobCommandBuilder.java
@@ -27,10 +27,8 @@ public class EHoldingsJobCommandBuilder implements JobCommandBuilder {
     try {
       params.put("packageSearchQuery", new JobParameter(eHoldingsExportConfig.getPackageSearchQuery()));
       params.put("titleSearchQuery", new JobParameter(eHoldingsExportConfig.getTitleSearchQuery()));
-      params.put("packageFields",
-        new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getPackageFields())));
-      params.put("titleFields",
-        new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getTitleFields())));
+      params.put("packageFields", new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getPackageFields())));
+      params.put("titleFields", new JobParameter(objectMapper.writeValueAsString(eHoldingsExportConfig.getTitleFields())));
       return new JobParameters(params);
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException(e);

--- a/src/main/java/org/folio/des/config/ServiceConfiguration.java
+++ b/src/main/java/org/folio/des/config/ServiceConfiguration.java
@@ -124,7 +124,7 @@ public class ServiceConfiguration {
     converters.put(ExportType.BURSAR_FEES_FINES, burSarFeeFinesJobCommandBuilder);
     converters.put(ExportType.CIRCULATION_LOG, circulationLogJobCommandBuilder);
     converters.put(ExportType.EDIFACT_ORDERS_EXPORT, edifactOrdersJobCommandBuilder);
-    converters.put(ExportType.EHOLDINGS, eHoldingsJobCommandBuilder);
+    converters.put(ExportType.E_HOLDINGS, eHoldingsJobCommandBuilder);
     return new JobCommandBuilderResolver(converters);
   }
 

--- a/src/main/java/org/folio/des/config/ServiceConfiguration.java
+++ b/src/main/java/org/folio/des/config/ServiceConfiguration.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.folio.des.builder.job.BulkEditQueryJobCommandBuilder;
 import org.folio.des.builder.job.BurSarFeeFinesJobCommandBuilder;
 import org.folio.des.builder.job.CirculationLogJobCommandBuilder;
+import org.folio.des.builder.job.EHoldingsJobCommandBuilder;
 import org.folio.des.builder.job.EdifactOrdersJobCommandBuilder;
 import org.folio.des.builder.job.EdifactOrdersJobCommandSchedulerBuilder;
 import org.folio.des.builder.job.JobCommandBuilder;
@@ -116,12 +117,14 @@ public class ServiceConfiguration {
   @Bean JobCommandBuilderResolver jobCommandBuilderResolver(BulkEditQueryJobCommandBuilder bulkEditQueryJobCommandBuilder,
                           BurSarFeeFinesJobCommandBuilder burSarFeeFinesJobCommandBuilder,
                           CirculationLogJobCommandBuilder circulationLogJobCommandBuilder,
-                          EdifactOrdersJobCommandBuilder edifactOrdersJobCommandBuilder) {
+                          EdifactOrdersJobCommandBuilder edifactOrdersJobCommandBuilder,
+                          EHoldingsJobCommandBuilder eHoldingsJobCommandBuilder) {
     Map<ExportType, JobCommandBuilder> converters = new HashMap<>();
     converters.put(ExportType.BULK_EDIT_QUERY, bulkEditQueryJobCommandBuilder);
     converters.put(ExportType.BURSAR_FEES_FINES, burSarFeeFinesJobCommandBuilder);
     converters.put(ExportType.CIRCULATION_LOG, circulationLogJobCommandBuilder);
     converters.put(ExportType.EDIFACT_ORDERS_EXPORT, edifactOrdersJobCommandBuilder);
+    converters.put(ExportType.EHOLDINGS, eHoldingsJobCommandBuilder);
     return new JobCommandBuilderResolver(converters);
   }
 

--- a/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
+++ b/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
@@ -59,7 +59,7 @@ class JobCommandBuilderResolverTest {
     "CIRCULATION_LOG, query",
     "BULK_EDIT_QUERY, query",
     "EDIFACT_ORDERS_EXPORT, edifactOrdersExport",
-    "E_HOLDINGS, packageSearchQuery"
+    "E_HOLDINGS, packageId"
   })
   void shouldBeCreateJobParameters(ExportType exportType, String paramsKey) {
     Optional<JobCommandBuilder> builder = resolver.resolve(exportType);
@@ -75,9 +75,10 @@ class JobCommandBuilderResolverTest {
     vendorEdiOrdersExportConfig.vendorId(UUID.randomUUID());
     vendorEdiOrdersExportConfig.setConfigName("TestConfig");
 
-    eHoldingsExportConfig.setPackageSearchQuery("package");
+    eHoldingsExportConfig.setPackageId("packageId");
+    eHoldingsExportConfig.setPackageSearchFilters("packageFilters");
     eHoldingsExportConfig.setPackageFields(List.of("packageField"));
-    eHoldingsExportConfig.setTitleSearchQuery("title");
+    eHoldingsExportConfig.setTitleSearchFilters("titleFilters");
     eHoldingsExportConfig.setTitleFields(List.of("titleField"));
 
     exportTypeSpecificParameters.setQuery("TestQuery");

--- a/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
+++ b/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
@@ -37,7 +37,7 @@ class JobCommandBuilderResolverTest {
     "CIRCULATION_LOG, CirculationLogJobCommandBuilder",
     "BULK_EDIT_QUERY, BulkEditQueryJobCommandBuilder",
     "EDIFACT_ORDERS_EXPORT, EdifactOrdersJobCommandBuilder",
-    "EHOLDINGS, EHoldingsJobCommandBuilder"
+    "E_HOLDINGS, EHoldingsJobCommandBuilder"
   })
   void shouldRetrieveBuilderForSpecifiedExportTypeIfBuilderIsRegisteredInTheResolver(ExportType exportType,
               String expBuilderClass) {
@@ -59,7 +59,7 @@ class JobCommandBuilderResolverTest {
     "CIRCULATION_LOG, query",
     "BULK_EDIT_QUERY, query",
     "EDIFACT_ORDERS_EXPORT, edifactOrdersExport",
-    "EHOLDINGS, packageSearchQuery"
+    "E_HOLDINGS, packageSearchQuery"
   })
   void shouldBeCreateJobParameters(ExportType exportType, String paramsKey) {
     Optional<JobCommandBuilder> builder = resolver.resolve(exportType);

--- a/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
+++ b/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
@@ -3,6 +3,8 @@ package org.folio.des.builder.job;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -34,7 +36,8 @@ class JobCommandBuilderResolverTest {
     "BURSAR_FEES_FINES, BurSarFeeFinesJobCommandBuilder",
     "CIRCULATION_LOG, CirculationLogJobCommandBuilder",
     "BULK_EDIT_QUERY, BulkEditQueryJobCommandBuilder",
-    "EDIFACT_ORDERS_EXPORT, EdifactOrdersJobCommandBuilder"
+    "EDIFACT_ORDERS_EXPORT, EdifactOrdersJobCommandBuilder",
+    "EHOLDINGS, EHoldingsJobCommandBuilder"
   })
   void shouldRetrieveBuilderForSpecifiedExportTypeIfBuilderIsRegisteredInTheResolver(ExportType exportType,
               String expBuilderClass) {
@@ -55,14 +58,16 @@ class JobCommandBuilderResolverTest {
     "BURSAR_FEES_FINES, bursarFeeFines",
     "CIRCULATION_LOG, query",
     "BULK_EDIT_QUERY, query",
-    "EDIFACT_ORDERS_EXPORT, edifactOrdersExport"
+    "EDIFACT_ORDERS_EXPORT, edifactOrdersExport",
+    "EHOLDINGS, packageSearchQuery"
   })
   void shouldBeCreateJobParameters(ExportType exportType, String paramsKey) {
     Optional<JobCommandBuilder> builder = resolver.resolve(exportType);
     Job job = new Job();
     ExportTypeSpecificParameters exportTypeSpecificParameters = new ExportTypeSpecificParameters();
-    BursarFeeFines bursarFeeFines = new BursarFeeFines();
     VendorEdiOrdersExportConfig vendorEdiOrdersExportConfig = new VendorEdiOrdersExportConfig();
+    EHoldingsExportConfig eHoldingsExportConfig = new EHoldingsExportConfig();
+    BursarFeeFines bursarFeeFines = new BursarFeeFines();
 
     bursarFeeFines.setDaysOutstanding(1);
     bursarFeeFines.addPatronGroupsItem("Test");
@@ -70,8 +75,14 @@ class JobCommandBuilderResolverTest {
     vendorEdiOrdersExportConfig.vendorId(UUID.randomUUID());
     vendorEdiOrdersExportConfig.setConfigName("TestConfig");
 
+    eHoldingsExportConfig.setPackageSearchQuery("package");
+    eHoldingsExportConfig.setPackageFields(List.of("packageField"));
+    eHoldingsExportConfig.setTitleSearchQuery("title");
+    eHoldingsExportConfig.setTitleFields(List.of("titleField"));
+
     exportTypeSpecificParameters.setQuery("TestQuery");
     exportTypeSpecificParameters.setBursarFeeFines(bursarFeeFines);
+    exportTypeSpecificParameters.seteHoldingsExportConfig(eHoldingsExportConfig);
 
     job.setEntityType(EntityType.USER);
     job.setExportTypeSpecificParameters(exportTypeSpecificParameters);


### PR DESCRIPTION
## Approach
- add new export type - 'eHoldings', this allows the UI application to show and filter new eHoldings jobs;
- add new request parameters (to ExportTypeSpecificParameters.json) needed to pass export fields, search params for titles search, and other params; see  [exportTypeSpecificParameters.json](https://issues.folio.org/secure/attachment/47086/47086_exportTypeSpecificParameters.json)  [eHoldingsExportConfig.json](https://issues.folio.org/secure/attachment/47090/47090_eHoldingsExportConfig.json)
- add new JobCommandBuilder for eHoldings, needed to take request parameters and pass in Kafka event;
- update ServiceConfiguration.java(jobCommandBuilderResolver) adding the newly created JobCommandBuilder there;

## Learning
https://issues.folio.org/browse/MODEXPS-94