### PR TITLE
MODEXPS-21 - Remove gen_random_uuid(), it fails in pgpool native replication

### DIFF
--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -14,4 +14,14 @@
     </sql>
   </changeSet>
 
+  <changeSet id="MODEXPS-21@drop pgcrypto" author="Arghya_Mitra">
+    <sql dbms="postgresql">
+      DROP EXTENSION pgcrypto CASCADE;
+    </sql>
+  </changeSet>
+
+  <changeSet id="MODEXPS-21@drop default value" author="Arghya_Mitra">
+    <dropDefaultValue tableName="JOB" columnName="id" />
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -16,7 +16,7 @@
 
   <changeSet id="MODEXPS-21@drop pgcrypto" author="Arghya_Mitra">
     <sql dbms="postgresql">
-      DROP EXTENSION pgcrypto CASCADE;
+      DROP EXTENSION IF EXISTS pgcrypto CASCADE;
     </sql>
   </changeSet>
 


### PR DESCRIPTION
[MODEXPS-21] Update (https://issues.folio.org/browse/MODEXPS-21)

## Purpose
Remove gen_random_uuid usage and remove usage of CREATE EXTENSION pgcrypto 

## Approach
1. Write SQL for drop the  extension pgcrypto if exists in db.changelog file 
2. Remove the default value from table using dropDefaultValue tag in db.changelog file .
