### PR TITLE
MODEXPS-21 - Remove gen_random_uuid() and changes as per review comment

### DIFF
--- a/src/main/resources/db/changelog/changes/create-db.xml
+++ b/src/main/resources/db/changelog/changes/create-db.xml
@@ -4,12 +4,6 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
-    <changeSet id="MODEXPS-1@@create-pgcrypto-extension" author="prokhorovalexey">
-        <sql dbms="postgresql">
-            CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public;
-        </sql>
-    </changeSet>
-
     <changeSet id="MODEXPS-1@@create-export-type-enum" author="prokhorovalexey">
         <sql dbms="postgresql">
             CREATE TYPE ExportType as ENUM ('CIRCULATION_LOG', 'BURSAR_FEES_FINES');

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -14,12 +14,6 @@
     </sql>
   </changeSet>
 
-  <changeSet id="MODEXPS-21@drop pgcrypto" author="Arghya_Mitra">
-    <sql dbms="postgresql">
-      DROP EXTENSION IF EXISTS pgcrypto CASCADE;
-    </sql>
-  </changeSet>
-
   <changeSet id="MODEXPS-21@drop default value" author="Arghya_Mitra">
     <dropDefaultValue tableName="JOB" columnName="id" />
   </changeSet>

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -14,4 +14,14 @@
     </sql>
   </changeSet>
 
+  <changeSet id="MODEXPS-21@drop pgcrypto" author="Arghya_Mitra">
+    <sql dbms="postgresql">
+      DROP EXTENSION pgcrypto CASCADE;
+    </sql>
+  </changeSet>
+
+  <changeSet id="MODEXPS-21@drop default value" author="Arghya_Mitra">
+    <dropDefaultValue tableName="JOB" columnName="id" />
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -16,7 +16,7 @@
 
   <changeSet id="MODEXPS-21@drop pgcrypto" author="Arghya_Mitra">
     <sql dbms="postgresql">
-      DROP EXTENSION pgcrypto CASCADE;
+      DROP EXTENSION IF EXISTS pgcrypto CASCADE;
     </sql>
   </changeSet>
 


### PR DESCRIPTION
[MODEXPS-21](https://issues.folio.org/browse/MODEXPS-21)

## Purpose
Remove gen_random_uuid usage
Remove drop extension pgcrypto
## Approach
1. Removed create extension pgcrypto changeSet from db.xml as per comment
2. Removed drop extension pgcrypto changeSet from chnagelog-1.4.0 as per comment as it can affect other module