### PR TITLE
Modexps 21 Remove gen_random_uuid(), it fails in pgpool native replication

### DIFF
--- a/src/main/resources/db/changelog/changes/create-db.xml
+++ b/src/main/resources/db/changelog/changes/create-db.xml
@@ -4,12 +4,6 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
-    <changeSet id="MODEXPS-1@@create-pgcrypto-extension" author="prokhorovalexey">
-        <sql dbms="postgresql">
-            CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public;
-        </sql>
-    </changeSet>
-
     <changeSet id="MODEXPS-1@@create-export-type-enum" author="prokhorovalexey">
         <sql dbms="postgresql">
             CREATE TYPE ExportType as ENUM ('CIRCULATION_LOG', 'BURSAR_FEES_FINES');

--- a/src/main/resources/db/changelog/changes/create-db.xml
+++ b/src/main/resources/db/changelog/changes/create-db.xml
@@ -40,7 +40,7 @@
 
     <changeSet id="MODEXPS-1@@create-job-table" author="prokhorovalexey">
         <createTable tableName="job">
-            <column name="id" type="uuid" defaultValueComputed="gen_random_uuid()">
+            <column name="id" type="uuid">
                 <constraints primaryKey="true" primaryKeyName="pk_job" nullable="false"/>
             </column>
 

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -14,8 +14,4 @@
     </sql>
   </changeSet>
 
-  <changeSet id="MODEXPS-21@drop default value" author="Arghya_Mitra">
-    <dropDefaultValue tableName="JOB" columnName="id" />
-  </changeSet>
-
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -14,12 +14,6 @@
     </sql>
   </changeSet>
 
-  <changeSet id="MODEXPS-21@drop pgcrypto" author="Arghya_Mitra">
-    <sql dbms="postgresql">
-      DROP EXTENSION IF EXISTS pgcrypto CASCADE;
-    </sql>
-  </changeSet>
-
   <changeSet id="MODEXPS-21@drop default value" author="Arghya_Mitra">
     <dropDefaultValue tableName="JOB" columnName="id" />
   </changeSet>

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -14,4 +14,14 @@
     </sql>
   </changeSet>
 
+  <changeSet id="MODEXPS-21@drop pgcrypto" author="Arghya_Mitra">
+    <sql dbms="postgresql">
+      DROP EXTENSION pgcrypto CASCADE;
+    </sql>
+  </changeSet>
+
+  <changeSet id="MODEXPS-21@drop default value" author="Arghya_Mitra">
+    <dropDefaultValue tableName="JOB" columnName="id" />
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -16,7 +16,7 @@
 
   <changeSet id="MODEXPS-21@drop pgcrypto" author="Arghya_Mitra">
     <sql dbms="postgresql">
-      DROP EXTENSION pgcrypto CASCADE;
+      DROP EXTENSION IF EXISTS pgcrypto CASCADE;
     </sql>
   </changeSet>
 


### PR DESCRIPTION
[MODEXPS-21](https://issues.folio.org/browse/MODEXPS-21)

## Purpose
Remove gen_random_uuid usage; use a hard-coded value, or generate UUID in Java
Remove "CREATE EXTENSION pgcrypto"

## Approach
1.Remove  defaultValueComputed="gen_random_uuid() from create-db.xml for changeSet id = MODEXPS1@@create-job-table
2. As we are removing the defaultValueComputed , we don't need changeSet id = [MODEXPS-21](https://issues.folio.org/browse/MODEXPS-21)@drop default value from db.changelog-1.4.0.xml .

