### PR TITLE
MODEXPS-106 -Update folio-export-common schemas

### DIFF
--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.0.xml
@@ -18,4 +18,11 @@
     <dropDefaultValue tableName="JOB" columnName="id" />
   </changeSet>
 
+  <changeSet id="MODEXPS-106@@update schemas" author="siarhei_charniak">
+    <sql dbms="postgresql">
+      ALTER TYPE IdentifierType ADD VALUE 'USER_NAME';
+      ALTER TYPE IdentifierType ADD VALUE 'EXTERNAL_SYSTEM_ID';
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/org/folio/des/controller/JobsControllerTest.java
+++ b/src/test/java/org/folio/des/controller/JobsControllerTest.java
@@ -308,6 +308,9 @@ class JobsControllerTest extends BaseTest {
 
   @ParameterizedTest
   @ValueSource(strings = {
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"USER\", \"identifierType\" : \"ID\"}",
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"USER\", \"identifierType\" : \"USER_NAME\"}",
+    "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"USER\", \"identifierType\" : \"EXTERNAL_SYSTEM_ID\"}",
     "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"USER\", \"identifierType\" : \"BARCODE\"}",
     "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"ITEM\", \"identifierType\" : \"ID\"}",
     "{ \"type\": \"BULK_EDIT_IDENTIFIERS\", \"exportTypeSpecificParameters\" : {}, \"entityType\" : \"ITEM\", \"identifierType\" : \"BARCODE\"}",


### PR DESCRIPTION
[MODEXPS-106](https://issues.folio.org/browse/MODEXPS-106) -Update folio-export-common schemas

## Purpose
Update folio-export-common schemas to support new User identifier types

## Approach
* Updated folio-export-common schemas
* Updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
