### PR TITLE
MODEXPS-119: RMB v34 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,8 @@
 
         <folio-spring-base.version>4.1.0</folio-spring-base.version>
         <hibernate-types-52.version>2.10.3</hibernate-types-52.version>
-        <cql2pgjson.version>32.2.0</cql2pgjson.version>
+        <cql2pgjson.version>34.0.0</cql2pgjson.version>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <json.version>20200518</json.version>
         <openapi-generator.version>4.3.1</openapi-generator.version>
 
         <sonar.exclusions>
@@ -116,12 +115,6 @@
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${json.version}</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
+++ b/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
@@ -36,8 +36,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 
-import io.vertx.core.json.JsonObject;
-
 class ConfigsControllerTest extends BaseTest {
 
   private static final String NEW_CONFIG_REQUEST =
@@ -65,7 +63,7 @@ class ConfigsControllerTest extends BaseTest {
     var config = new ConfigurationCollection();
     config.setTotalRecords(0);
     wireMockServer.stubFor(WireMock.get(anyUrl())
-      .willReturn(aResponse().withBody(JsonObject.mapFrom(config).encode())
+      .willReturn(aResponse().withBody(asJsonString(config))
         .withHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .withStatus(200)));
 
@@ -181,7 +179,7 @@ class ConfigsControllerTest extends BaseTest {
     modelConfiguration.setModule(DEFAULT_MODULE_NAME);
     modelConfiguration.setValue(UPDATE_CONFIG_REQUEST);
     wireMockServer.stubFor(WireMock.get(urlEqualTo(urlById))
-      .willReturn(aResponse().withBody(JsonObject.mapFrom(modelConfiguration).encode())
+      .willReturn(aResponse().withBody(asJsonString(modelConfiguration))
         .withHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .withStatus(200)));
 


### PR DESCRIPTION
Upgrade RMB (= cql2pgjson) from 32.2.0 to 34.0.0.

Remove org.json:json, it doesn't have an Open Source license:
https://github.com/stleary/JSON-java#overview
https://en.wikipedia.org/wiki/Douglas_Crockford#%22Good,_not_Evil%22

Replace Vert.x JsonObject with jackson-databind ObjectMapper
and ObjectNode.