### PR TITLE
[MODEXPS-88]. Filter organization export logs limited to 10 options

### DIFF
--- a/src/main/java/org/folio/des/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/des/client/ConfigurationClient.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface ConfigurationClient {
 
   @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-  ConfigurationCollection getConfigurations(@RequestParam("query") String query);
+  ConfigurationCollection getConfigurations(@RequestParam("query") String query, @RequestParam("limit") Integer limit);
 
   @PostMapping
   ModelConfiguration postConfiguration(@RequestBody ModelConfiguration config);

--- a/src/main/java/org/folio/des/controller/ConfigsController.java
+++ b/src/main/java/org/folio/des/controller/ConfigsController.java
@@ -24,8 +24,8 @@ public class ConfigsController implements ConfigsApi {
   private final ExportTypeBasedConfigManager manager;
 
   @Override
-  public ResponseEntity<ExportConfigCollection> getExportConfigs(String query) {
-      return ResponseEntity.ok(manager.getConfigCollection(query));
+  public ResponseEntity<ExportConfigCollection> getExportConfigs(String query, Integer limit) {
+      return ResponseEntity.ok(manager.getConfigCollection(query, limit));
   }
 
   @Override

--- a/src/main/java/org/folio/des/scheduling/acquisition/EdifactScheduledJobInitializer.java
+++ b/src/main/java/org/folio/des/scheduling/acquisition/EdifactScheduledJobInitializer.java
@@ -30,7 +30,7 @@ public class EdifactScheduledJobInitializer {
       boolean isJobScheduleAllowed = isJobScheduleAllowed(acqSchedulingProperties.isRunOnlyIfModuleRegistered(),
                                                           contextHelper.isModuleRegistered());
       if (isJobScheduleAllowed) {
-        ExportConfigCollection exportConfigCol = basedConfigManager.getConfigCollection(ALL_EDIFACT_ORDERS_CONFIG_QUERY);
+        ExportConfigCollection exportConfigCol = basedConfigManager.getConfigCollection(ALL_EDIFACT_ORDERS_CONFIG_QUERY, Integer.MAX_VALUE);
         exportConfigs = exportConfigCol.getConfigs();
         for (ExportConfig exportConfig : exportConfigs) {
           List<Job> scheduledJobs = exportJobScheduler.scheduleExportJob(exportConfig);

--- a/src/main/java/org/folio/des/service/config/BulkEditConfigService.java
+++ b/src/main/java/org/folio/des/service/config/BulkEditConfigService.java
@@ -27,7 +27,7 @@ public class BulkEditConfigService {
   private final ConfigurationClient configurationClient;
 
   public ConfigurationCollection getBulkEditConfigurations() {
-    return configurationClient.getConfigurations(String.format(BULK_EDIT_CONFIGURATIONS_QUERY_TEMPLATE, MODULE_NAME, CONFIG_NAME));
+    return configurationClient.getConfigurations(String.format(BULK_EDIT_CONFIGURATIONS_QUERY_TEMPLATE, MODULE_NAME, CONFIG_NAME), Integer.MAX_VALUE);
   }
 
   @SneakyThrows

--- a/src/main/java/org/folio/des/service/config/BulkEditConfigService.java
+++ b/src/main/java/org/folio/des/service/config/BulkEditConfigService.java
@@ -26,13 +26,13 @@ import java.util.Map;
 public class BulkEditConfigService {
   private final ConfigurationClient configurationClient;
 
-  public ConfigurationCollection getBulkEditConfigurations() {
-    return configurationClient.getConfigurations(String.format(BULK_EDIT_CONFIGURATIONS_QUERY_TEMPLATE, MODULE_NAME, CONFIG_NAME), Integer.MAX_VALUE);
+  public ConfigurationCollection getBulkEditConfigurations(Integer limit) {
+    return configurationClient.getConfigurations(String.format(BULK_EDIT_CONFIGURATIONS_QUERY_TEMPLATE, MODULE_NAME, CONFIG_NAME), limit);
   }
 
   @SneakyThrows
   public int getBulkEditJobExpirationPeriod() {
-    var configs = getBulkEditConfigurations();
+    var configs = getBulkEditConfigurations(1);
     if (!configs.getConfigs().isEmpty()) {
       var config = configs.getConfigs().get(0);
       log.info("Found bulk-edit configuration: {}", config);
@@ -43,7 +43,7 @@ public class BulkEditConfigService {
   }
 
   public void checkBulkEditConfiguration() {
-    if (getBulkEditConfigurations().getConfigs().isEmpty()) {
+    if (getBulkEditConfigurations(1).getConfigs().isEmpty()) {
       log.info("Bulk-edit configuration was not found, uploading default");
       configurationClient.postConfiguration(buildDefaultConfig());
     }

--- a/src/main/java/org/folio/des/service/config/ExportConfigService.java
+++ b/src/main/java/org/folio/des/service/config/ExportConfigService.java
@@ -11,7 +11,7 @@ public interface ExportConfigService {
 
   ModelConfiguration postConfig(ExportConfig exportConfig);
 
-  ExportConfigCollection getConfigCollection(String query);
+  ExportConfigCollection getConfigCollection(String query, Integer limit);
 
   Optional<ExportConfig> getFirstConfig();
 }

--- a/src/main/java/org/folio/des/service/config/impl/BaseExportConfigService.java
+++ b/src/main/java/org/folio/des/service/config/impl/BaseExportConfigService.java
@@ -48,8 +48,8 @@ public class BaseExportConfigService implements ExportConfigService {
   }
 
   @Override
-  public ExportConfigCollection getConfigCollection(String query) {
-    ConfigurationCollection configurationCollection = client.getConfigurations(query);
+  public ExportConfigCollection getConfigCollection(String query, Integer limit) {
+    ConfigurationCollection configurationCollection = client.getConfigurations(query, limit);
     if (configurationCollection.getTotalRecords() > 0) {
       var exportConfigCollection = new ExportConfigCollection();
       configurationCollection.getConfigs().forEach(modelConfig -> exportConfigCollection
@@ -62,7 +62,7 @@ public class BaseExportConfigService implements ExportConfigService {
 
   @Override
   public Optional<ExportConfig> getFirstConfig() {
-    var configurationCollection = getConfigCollection(StringUtils.EMPTY);
+    var configurationCollection = getConfigCollection(StringUtils.EMPTY, 1);
     if (configurationCollection.getTotalRecords() == 0) {
       return Optional.empty();
     }

--- a/src/main/java/org/folio/des/service/config/impl/BurSarFeesFinesExportConfigService.java
+++ b/src/main/java/org/folio/des/service/config/impl/BurSarFeesFinesExportConfigService.java
@@ -25,13 +25,13 @@ public class BurSarFeesFinesExportConfigService extends BaseExportConfigService 
   }
 
   @Override
-  public ExportConfigCollection getConfigCollection(String query) {
+  public ExportConfigCollection getConfigCollection(String query, Integer limit) {
     return getFirstConfig().map(this::createExportConfigCollection).orElse(emptyExportConfigCollection());
   }
 
   @Override
   public Optional<ExportConfig> getFirstConfig() {
-    var configurationCollection = client.getConfigurations(String.format(DEFAULT_CONFIG_QUERY, DEFAULT_CONFIG_NAME));
+    var configurationCollection = client.getConfigurations(String.format(DEFAULT_CONFIG_QUERY, DEFAULT_CONFIG_NAME), 1);
     if (configurationCollection.getTotalRecords() == 0) {
       return Optional.empty();
     }

--- a/src/main/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManager.java
+++ b/src/main/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManager.java
@@ -59,16 +59,16 @@ public class ExportTypeBasedConfigManager {
     return defaultExportConfigService.postConfig(exportConfig);
   }
 
-  public ExportConfigCollection getConfigCollection(String query) {
+  public ExportConfigCollection getConfigCollection(String query, Integer limit) {
     Optional<ExportType> exportTypeOpt = extractExportType(query);
     String normalizedQuery = normalizeQuery(exportTypeOpt, query);
     if (exportTypeOpt.isPresent()) {
       Optional<ExportConfigService> exportConfigService = exportConfigServiceResolver.resolve(exportTypeOpt.get());
       if (exportConfigService.isPresent()) {
-        return exportConfigService.get().getConfigCollection(normalizedQuery);
+        return exportConfigService.get().getConfigCollection(normalizedQuery, limit);
       }
     }
-    return defaultExportConfigService.getConfigCollection(normalizedQuery);
+    return defaultExportConfigService.getConfigCollection(normalizedQuery, limit);
   }
 
   public ExportConfig getConfigById(String exportConfigId) {

--- a/src/main/resources/swagger.api/export-configs.yaml
+++ b/src/main/resources/swagger.api/export-configs.yaml
@@ -9,6 +9,7 @@ paths:
     get:
       parameters:
         - $ref: "#/components/parameters/trait_queryable_query"
+        - $ref: "#/components/parameters/trait_pageable_limit"
       description: Get a list of data export configurations
       operationId: getExportConfigs
       responses:
@@ -208,6 +209,13 @@ components:
       description: A query string to filter rules based on matching criteria in fields.
       schema:
         type: string
+    trait_pageable_limit:
+      name: limit
+      in: query
+      description: Limit the number of elements returned in the response
+      schema:
+        default: 10
+        type: integer
   examples:
     errors:
       value:

--- a/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
+++ b/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
@@ -7,6 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.folio.des.service.config.ExportConfigConstants.DEFAULT_MODULE_NAME;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.ResultMatcher.matchAll;
@@ -78,7 +79,7 @@ class ConfigsControllerTest extends BaseTest {
                 content().contentType(MediaType.APPLICATION_JSON_VALUE),
                 jsonPath("$.totalRecords", is(0))));
 
-    verify(configurationClient, times(1)).getConfigurations(modConfigQuery);
+    verify(configurationClient, times(1)).getConfigurations(eq(modConfigQuery), any());
   }
 
   @Test

--- a/src/test/java/org/folio/des/scheduling/ExportTriggerTest.java
+++ b/src/test/java/org/folio/des/scheduling/ExportTriggerTest.java
@@ -301,7 +301,7 @@ class ExportTriggerTest {
     config.setSchedulePeriod(ExportConfig.SchedulePeriodEnum.DAY);
     config.setExportTypeSpecificParameters(new ExportTypeSpecificParameters());
     var now = LocalDateTime.now(ZoneId.of("UTC")).plusMinutes(1);
-    config.setScheduleTime(now.getHour() + ":" + adjustMinute(now.getMinute()) + ":00.000Z");
+    config.setScheduleTime(adjustHourOrMinute(now.getHour()) + ":" + adjustHourOrMinute(now.getMinute()) + ":00.000Z");
     config.setScheduleFrequency(1);
     config.setTenant("diku");
     trigger.setConfig(config);
@@ -320,10 +320,10 @@ class ExportTriggerTest {
     return expected;
   }
 
-  private String adjustMinute(int minute) {
-    if (minute < 10) {
-      return "0" + minute;
+  private String adjustHourOrMinute(int val) {
+    if (val < 10) {
+      return "0" + val;
     }
-    return String.valueOf(minute);
+    return String.valueOf(val);
   }
 }

--- a/src/test/java/org/folio/des/scheduling/acquisition/EdifactScheduledJobInitializerTest.java
+++ b/src/test/java/org/folio/des/scheduling/acquisition/EdifactScheduledJobInitializerTest.java
@@ -1,7 +1,6 @@
 package org.folio.des.scheduling.acquisition;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -37,7 +36,7 @@ class EdifactScheduledJobInitializerTest {
     //When
     initializer.initAllScheduledJob();
     //Then
-    verify(exportTypeBasedConfigManager, times(0)).getConfigCollection(anyString());
+    verify(exportTypeBasedConfigManager, times(0)).getConfigCollection(anyString(), eq(Integer.MAX_VALUE));
     verify(exportJobScheduler, times(0)).scheduleExportJob(any(ExportConfig.class));
   }
 
@@ -49,11 +48,11 @@ class EdifactScheduledJobInitializerTest {
     ExportConfig exportConfig = new ExportConfig();
     exportConfig.setId(UUID.randomUUID().toString());
     configCollection.addConfigsItem(exportConfig);
-    doReturn(configCollection).when(exportTypeBasedConfigManager).getConfigCollection(anyString());
+    doReturn(configCollection).when(exportTypeBasedConfigManager).getConfigCollection(anyString(), eq(Integer.MAX_VALUE));
     //When
     initializer.initAllScheduledJob();
     //Then
-    verify(exportTypeBasedConfigManager, times(1)).getConfigCollection(anyString());
+    verify(exportTypeBasedConfigManager, times(1)).getConfigCollection(anyString(), eq(Integer.MAX_VALUE));
     verify(exportJobScheduler, times(1)).scheduleExportJob(any(ExportConfig.class));
   }
 
@@ -61,7 +60,7 @@ class EdifactScheduledJobInitializerTest {
   void shouldSkipScheduleJobsIfNoExportConfigs() {
     doReturn(false).when(contextHelper).isModuleRegistered();
     doReturn(true).when(acqSchedulingProperties).isRunOnlyIfModuleRegistered();
-    doReturn(new ExportConfigCollection()).when(exportTypeBasedConfigManager).getConfigCollection(anyString());
+    doReturn(new ExportConfigCollection()).when(exportTypeBasedConfigManager).getConfigCollection(anyString(), eq(Integer.MAX_VALUE));
     //When
     initializer.initAllScheduledJob();
     //Then

--- a/src/test/java/org/folio/des/service/config/acquisition/EdifactOrdersExportServiceTest.java
+++ b/src/test/java/org/folio/des/service/config/acquisition/EdifactOrdersExportServiceTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 @SpringBootTest(classes = {DefaultModelConfigToExportConfigConverter.class, JacksonConfiguration.class,
   ServiceConfiguration.class})
@@ -81,7 +82,7 @@ class EdifactOrdersExportServiceTest {
   @DisplayName("Config is not set")
   void noConfig() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(EMPTY_CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(1))).thenReturn(mockedResponse);
 
     var config = service.getFirstConfig();
 

--- a/src/test/java/org/folio/des/service/config/impl/BaseExportConfigServiceTest.java
+++ b/src/test/java/org/folio/des/service/config/impl/BaseExportConfigServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.List;
 import java.util.UUID;
@@ -138,7 +139,7 @@ class BaseExportConfigServiceTest {
   @DisplayName("Config is not set")
   void noConfig() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(EMPTY_CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(1))).thenReturn(mockedResponse);
 
     var config = service.getFirstConfig();
 
@@ -149,10 +150,10 @@ class BaseExportConfigServiceTest {
   @DisplayName("Fetch empty config collection")
   void fetchEmptyConfigCollection() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(EMPTY_CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(1))).thenReturn(mockedResponse);
 
     var query = String.format(DEFAULT_CONFIG_QUERY, DEFAULT_CONFIG_NAME);
-    var config = service.getConfigCollection(query);
+    var config = service.getConfigCollection(query, 1);
 
     Assertions.assertAll(
         () -> assertEquals(0, config.getTotalRecords()),
@@ -163,10 +164,10 @@ class BaseExportConfigServiceTest {
   @DisplayName("Fetch config collection")
   void fetchConfigCollection() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(1))).thenReturn(mockedResponse);
 
     var query = String.format(DEFAULT_CONFIG_QUERY, DEFAULT_CONFIG_NAME);
-    var config = service.getConfigCollection(query);
+    var config = service.getConfigCollection(query, 1);
 
     Assertions.assertAll(
         () -> assertEquals(1, config.getTotalRecords()),
@@ -185,7 +186,7 @@ class BaseExportConfigServiceTest {
   @DisplayName("Config exists and parsed correctly")
   void getConfig() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(1))).thenReturn(mockedResponse);
 
     var config = service.getFirstConfig();
 

--- a/src/test/java/org/folio/des/service/config/impl/BurSarFeesFinesExportConfigServiceTest.java
+++ b/src/test/java/org/folio/des/service/config/impl/BurSarFeesFinesExportConfigServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.List;
 import java.util.UUID;
@@ -138,7 +139,7 @@ class BurSarFeesFinesExportConfigServiceTest {
   @DisplayName("Config is not set")
   void noConfig() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(EMPTY_CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(1))).thenReturn(mockedResponse);
 
     var config = service.getFirstConfig();
 
@@ -149,10 +150,10 @@ class BurSarFeesFinesExportConfigServiceTest {
   @DisplayName("Fetch empty config collection")
   void fetchEmptyConfigCollection() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(EMPTY_CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(1))).thenReturn(mockedResponse);
 
     var query = String.format(DEFAULT_CONFIG_QUERY, DEFAULT_CONFIG_NAME);
-    var config = service.getConfigCollection(query);
+    var config = service.getConfigCollection(query, 1);
 
     Assertions.assertAll(
         () -> assertEquals(0, config.getTotalRecords()),
@@ -163,10 +164,10 @@ class BurSarFeesFinesExportConfigServiceTest {
   @DisplayName("Fetch config collection")
   void fetchConfigCollection() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(1))).thenReturn(mockedResponse);
 
     var query = String.format(DEFAULT_CONFIG_QUERY, DEFAULT_CONFIG_NAME);
-    var config = service.getConfigCollection(query);
+    var config = service.getConfigCollection(query, 1);
 
     Assertions.assertAll(
         () -> assertEquals(1, config.getTotalRecords()),
@@ -185,7 +186,7 @@ class BurSarFeesFinesExportConfigServiceTest {
   @DisplayName("Config exists and parsed correctly")
   void getConfig() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(1))).thenReturn(mockedResponse);
 
     var config = service.getFirstConfig();
 

--- a/src/test/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManagerTest.java
+++ b/src/test/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManagerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.List;
 import java.util.UUID;
@@ -160,9 +161,9 @@ class ExportTypeBasedConfigManagerTest {
   @DisplayName("Config is not set")
   void noConfig() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(EMPTY_CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), any())).thenReturn(mockedResponse);
 
-    var configs = service.getConfigCollection( null);
+    var configs = service.getConfigCollection(null, 10);
 
     assertTrue(configs.getConfigs().isEmpty());
   }
@@ -171,10 +172,10 @@ class ExportTypeBasedConfigManagerTest {
   @DisplayName("Fetch empty config collection")
   void fetchEmptyConfigCollection() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(EMPTY_CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(10))).thenReturn(mockedResponse);
 
     var query = String.format(DEFAULT_CONFIG_QUERY, DEFAULT_CONFIG_NAME);
-    var config = service.getConfigCollection(query);
+    var config = service.getConfigCollection(query, 10);
 
     Assertions.assertAll(
         () -> assertEquals(0, config.getTotalRecords()),
@@ -185,10 +186,10 @@ class ExportTypeBasedConfigManagerTest {
   @DisplayName("Fetch config collection")
   void fetchConfigCollection() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(10))).thenReturn(mockedResponse);
 
     var query = String.format(DEFAULT_CONFIG_QUERY, DEFAULT_CONFIG_NAME);
-    var config = service.getConfigCollection(query);
+    var config = service.getConfigCollection(query, 10);
 
     Assertions.assertAll(
         () -> assertEquals(1, config.getTotalRecords()),
@@ -207,9 +208,9 @@ class ExportTypeBasedConfigManagerTest {
   @DisplayName("Config exists and parsed correctly")
   void getConfig() throws JsonProcessingException {
     final ConfigurationCollection mockedResponse = objectMapper.readValue(CONFIG_RESPONSE, ConfigurationCollection.class);
-    Mockito.when(client.getConfigurations(any())).thenReturn(mockedResponse);
+    Mockito.when(client.getConfigurations(any(), eq(10))).thenReturn(mockedResponse);
 
-    var configs  = service.getConfigCollection(null);
+    var configs  = service.getConfigCollection(null, 10);
 
     assertEquals(1, configs.getTotalRecords());
 

--- a/src/test/resources/mappings/configurations.json
+++ b/src/test/resources/mappings/configurations.json
@@ -3,7 +3,7 @@
     {
       "request": {
         "method": "GET",
-        "url": "/configurations/entries?query=module%3D%3Dmod-data-export-spring%20and%20configName%3D%3Dexport_config_parameters"
+        "url": "/configurations/entries?query=module%3D%3Dmod-data-export-spring%20and%20configName%3D%3Dexport_config_parameters&limit=1"
       },
       "response": {
         "status": 200,
@@ -42,7 +42,7 @@
     {
       "request": {
         "method": "GET",
-        "url": "/configurations/entries?query=module%3D%3DBULKEDIT%20and%20configName%3D%3Dgeneral"
+        "url": "/configurations/entries?query=module%3D%3DBULKEDIT%20and%20configName%3D%3Dgeneral&limit=2147483647"
       },
       "response": {
         "status": 200,

--- a/src/test/resources/mappings/configurations.json
+++ b/src/test/resources/mappings/configurations.json
@@ -42,7 +42,7 @@
     {
       "request": {
         "method": "GET",
-        "url": "/configurations/entries?query=module%3D%3DBULKEDIT%20and%20configName%3D%3Dgeneral&limit=2147483647"
+        "url": "/configurations/entries?query=module%3D%3DBULKEDIT%20and%20configName%3D%3Dgeneral&limit=1"
       },
       "response": {
         "status": 200,


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODEXPS-88
Additionally to fix issue reported in Jira this PR also fixes Edifact scheduler issues to be able to pick up all configured configs for exports, not only the first 10 ones.

## Approach
Add limit param to query mod-configuration that allows to fetch all necessary records, not only first 10 configs as it was before
