### PR TITLE
MODEXPS-132 - Kafka: increase number of partitions, set concurrency level for listener and implement KafkaRecordInterceptor

### DIFF
--- a/src/main/java/org/folio/des/config/kafka/KafkaConfiguration.java
+++ b/src/main/java/org/folio/des/config/kafka/KafkaConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.RecordInterceptor;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.stereotype.Component;
@@ -31,9 +32,10 @@ public class KafkaConfiguration {
   private final KafkaProperties kafkaProperties;
 
   @Bean
-  public <V> ConcurrentKafkaListenerContainerFactory<String, V> kafkaListenerContainerFactory(ConsumerFactory<String, V> cf) {
+  public <V> ConcurrentKafkaListenerContainerFactory<String, V> kafkaListenerContainerFactory(ConsumerFactory<String, V> cf, RecordInterceptor<String, V> recordInterceptor) {
     var factory = new ConcurrentKafkaListenerContainerFactory<String, V>();
     factory.setConsumerFactory(cf);
+    factory.setRecordInterceptor(recordInterceptor);
     if (kafkaProperties.getListener().getAckMode() != null) {
       factory.getContainerProperties().setAckMode(kafkaProperties.getListener().getAckMode());
     }
@@ -47,7 +49,7 @@ public class KafkaConfiguration {
     props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
     props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
-    props.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, KafkaConsumerInterceptor.class.getName());
+//    props.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, KafkaConsumerInterceptor.class.getName());
     props.put("folioModuleMetadata", folioModuleMetadata);
     return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), deserializer);
   }

--- a/src/main/java/org/folio/des/config/kafka/KafkaRecordInterceptor.java
+++ b/src/main/java/org/folio/des/config/kafka/KafkaRecordInterceptor.java
@@ -1,0 +1,58 @@
+package org.folio.des.config.kafka;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.springframework.kafka.listener.RecordInterceptor;
+import org.springframework.stereotype.Component;
+
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.folio.spring.scope.FolioExecutionScopeExecutionContextManager;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class KafkaRecordInterceptor<V> implements RecordInterceptor<String, V> {
+
+  private final FolioModuleMetadata folioModuleMetadata;
+
+  @Override
+  public ConsumerRecord<String, V> intercept(ConsumerRecord<String, V> consumerRecord) {
+    Map<String, Collection<String>> okapiHeaders = headersToMap(consumerRecord.headers());
+
+    var defaultFolioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, okapiHeaders);
+    FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext(defaultFolioExecutionContext);
+    log.info("FOLIO context initialized RecordInterceptor.");
+
+    return consumerRecord;
+  }
+
+  @Override
+  public void afterRecord(ConsumerRecord<String, V> record, Consumer<String, V> consumer) {
+  }
+
+  private Map<String, Collection<String>> headersToMap(Headers header) {
+    Iterator<Header> headerIterator = header.iterator();
+    Map<String, Collection<String>> okapiHeaders = new HashMap<>();
+    while (headerIterator.hasNext()) {
+      var next = headerIterator.next();
+      if (next.key().startsWith(XOkapiHeaders.OKAPI_HEADERS_PREFIX)) {
+        var value = List.of(new String(next.value(), StandardCharsets.UTF_8));
+        okapiHeaders.put(next.key(), value);
+      }
+    }
+    return okapiHeaders;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,5 +51,8 @@ feign:
         loggerLevel: basic
 application:
   kafka:
+    topic-configuration:
+      "data-export.job.command":
+        partitions: ${DATA_EXPORT_JOB_COMMAND_TOPIC_PARTITIONS:50}
     topic-pattern: ${ENV:folio}.(.*\.)?data-export.job.update
     group-id: ${ENV:folio}-mod-data-export-spring-events-group

--- a/src/test/java/org/folio/des/support/BaseTest.java
+++ b/src/test/java/org/folio/des/support/BaseTest.java
@@ -37,7 +37,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ContextConfiguration(initializers = BaseTest.DockerPostgreDataSourceInitializer.class)
 @AutoConfigureMockMvc
 @Testcontainers
-@EmbeddedKafka(topics = { "diku.data-export.job.update", "diku.data-export.job.command" })
+@EmbeddedKafka(topics = { "diku.data-export.job.update" })
 @EnableKafka
 public abstract class BaseTest {
 


### PR DESCRIPTION
[MODEXPS-132](https://issues.folio.org/browse/MODEXPS-132) - Kafka: increase number of partitions, set concurrency level for listener and implement KafkaRecordInterceptor

## Purpose
Current implementation of Kafka allows consuming more than one record at a time, so the FolioExecutionContext is initialized by the tenant comes only from the last record. Also there is only 1 partition that prevents us from setting concurrency level for KafkaListener.

## Approach
* Allow increasing number of partitions (50 by default).
* Set concurrency level for KafkaListener to 30
* Implement KafkaRecordInterceptor instead of KafkaConsumerInterceptor

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
