### PR TITLE
[MODEXPS-97]. Export time is set as when configuration is saved rather than the time chosen in the UI

### DIFF
--- a/src/main/java/org/folio/des/builder/scheduling/BaseScheduledTaskBuilder.java
+++ b/src/main/java/org/folio/des/builder/scheduling/BaseScheduledTaskBuilder.java
@@ -32,7 +32,7 @@ public class BaseScheduledTaskBuilder implements ScheduledTaskBuilder {
       log.info("configureTasks attempt to execute at: {}: is module registered: {} ", current, contextHelper.isModuleRegistered());
       if (contextHelper.isModuleRegistered()) {
         contextHelper.initScope(job.getTenant());
-        Job resultJob = jobService.upsert(job, true);
+        Job resultJob = jobService.upsertAndSendToKafka(job, true);
         log.info("configureTasks executed for jobId: {} at: {}", resultJob.getId(), current);
         contextHelper.finishContext();
       }

--- a/src/main/java/org/folio/des/builder/scheduling/EdifactScheduledTaskBuilder.java
+++ b/src/main/java/org/folio/des/builder/scheduling/EdifactScheduledTaskBuilder.java
@@ -37,7 +37,7 @@ public class EdifactScheduledTaskBuilder extends BaseScheduledTaskBuilder {
                                                                        contextHelper.isModuleRegistered());
       if (isJobScheduleAllowed) {
           contextHelper.initScope(job.getTenant());
-          Job resultJob = jobService.upsert(job, false);
+          Job resultJob = jobService.upsertAndSendToKafka(job, false);
           log.info("Configured task saved in DB jobId: {}", resultJob.getId());
           if (resultJob.getId() != null) {
             var jobCommand = jobSchedulerCommandBuilder.buildJobCommand(resultJob);

--- a/src/main/java/org/folio/des/controller/JobsController.java
+++ b/src/main/java/org/folio/des/controller/JobsController.java
@@ -47,7 +47,7 @@ public class JobsController implements JobsApi {
     if (isMissingRequiredParameters(job)) {
       return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
-    return new ResponseEntity<>(service.upsert(job, true), job.getId() == null ? HttpStatus.CREATED : HttpStatus.OK);
+    return new ResponseEntity<>(service.upsertAndSendToKafka(job, true), job.getId() == null ? HttpStatus.CREATED : HttpStatus.OK);
   }
 
   private boolean isMissingRequiredParameters(Job job) {

--- a/src/main/java/org/folio/des/scheduling/ExportScheduler.java
+++ b/src/main/java/org/folio/des/scheduling/ExportScheduler.java
@@ -1,8 +1,6 @@
 package org.folio.des.scheduling;
 
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import java.util.Date;
 import java.util.Optional;
@@ -57,7 +55,7 @@ public class ExportScheduler implements SchedulingConfigurer {
       log.info("configureTasks attempt to execute at: {}: is module registered: {} ", current, contextHelper.isModuleRegistered());
       if (contextHelper.isModuleRegistered()) {
         contextHelper.initScope(scheduledJob.getTenant());
-        Job resultJob = jobService.upsert(scheduledJob, true);
+        Job resultJob = jobService.upsertAndSendToKafka(scheduledJob, true);
         log.info("configureTasks executed for jobId: {} at: {}", resultJob.getId(), current);
         contextHelper.finishContext();
       }

--- a/src/main/java/org/folio/des/scheduling/acquisition/AcqBaseExportTaskTrigger.java
+++ b/src/main/java/org/folio/des/scheduling/acquisition/AcqBaseExportTaskTrigger.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.folio.des.domain.dto.ScheduleParameters;
 import org.folio.des.scheduling.base.AbstractExportTaskTrigger;
 import org.folio.des.scheduling.base.ScheduleDateTimeUtil;
@@ -126,36 +127,54 @@ public class AcqBaseExportTaskTrigger extends AbstractExportTaskTrigger {
 
   @SneakyThrows
   private Date scheduleTaskWithHourPeriod(Date lastActualExecutionTime, Integer hours) {
-    ZonedDateTime startTimeUTC = ScheduleDateTimeUtil.convertScheduleTime(lastActualExecutionTime, scheduleParameters);
-    ZoneId zoneId = ZoneId.of("UTC");
-    ZonedDateTime nowDate = Instant.now().atZone(zoneId);
+    ZonedDateTime startTime = ScheduleDateTimeUtil.convertScheduleTime(lastActualExecutionTime, scheduleParameters);
+
     if (lastActualExecutionTime != null) {
-      long diffHours = (nowDate.toInstant().toEpochMilli() - startTimeUTC.toInstant().toEpochMilli())/(60 * 60 * 1000);
+      ZoneId zoneId = ZoneId.of("UTC");
+      ZonedDateTime nowDate = Instant.now().atZone(zoneId);
+      long diffHours = (nowDate.toInstant().toEpochMilli() - startTime.toInstant().toEpochMilli())/(60 * 60 * 1000);
       if (diffHours > 0 && hours !=0 && diffHours > hours) {
         BigDecimal hoursToIncrease = BigDecimal.valueOf(diffHours)
           .divide(BigDecimal.valueOf(hours), RoundingMode.FLOOR)
           .add(BigDecimal.ONE);
-        startTimeUTC = startTimeUTC.plusHours(hoursToIncrease.longValue() * hours);
-      } else
-      {
-        startTimeUTC = startTimeUTC.plusHours(hours);
+        startTime = startTime.plusHours(hoursToIncrease.longValue() * hours);
+      } else {
+        startTime = startTime.plusHours(hours);
       }
     }
-    log.info("Hourly next schedule execution time in UTC for config {} is : {}", scheduleParameters.getId(), startTimeUTC);
-    return ScheduleDateTimeUtil.convertToOldDateFormat(startTimeUTC, scheduleParameters);
+
+    startTime = normalizeIfNextRunInPast(startTime, getNowDateTime(scheduleParameters.getTimeZone()));
+
+    log.info("Hourly next schedule execution time in {} for config {} is : {}", scheduleParameters.getTimeZone(), scheduleParameters.getId(), startTime);
+    return ScheduleDateTimeUtil.convertToOldDateFormat(startTime, scheduleParameters);
   }
 
   @SneakyThrows
   private Date scheduleTaskWithDayPeriod(Date lastActualExecutionTime, Integer days) {
-    ZonedDateTime startTimeUTC = ScheduleDateTimeUtil.convertScheduleTime(lastActualExecutionTime, scheduleParameters);
+    ZonedDateTime startTime = ScheduleDateTimeUtil.convertScheduleTime(lastActualExecutionTime, scheduleParameters);
     if (lastActualExecutionTime != null) {
-      startTimeUTC = startTimeUTC.plusDays(days);
+      startTime = startTime.plusDays(days);
     }
-    log.info("Day next schedule execution time in UTC for config {} is : {}", scheduleParameters.getId(), startTimeUTC);
-    return ScheduleDateTimeUtil.convertToOldDateFormat(startTimeUTC, scheduleParameters);
+
+    log.info("Day next schedule execution time in {} for config {} is : {}", scheduleParameters.getTimeZone(), scheduleParameters.getId(), startTime);
+    return ScheduleDateTimeUtil.convertToOldDateFormat(startTime, scheduleParameters);
   }
 
+  private ZonedDateTime normalizeIfNextRunInPast(ZonedDateTime startTime, ZonedDateTime nowTime) {
+    if (startTime.isBefore(nowTime)) {
+      if (startTime.getMinute() > nowTime.getMinute()) {
+        return nowTime.withMinute(startTime.getMinute());
+      } else {
+        return nowTime.plusHours(1).withMinute(startTime.getMinute());
+      }
+    }
+    return startTime;
+  }
 
+  private ZonedDateTime getNowDateTime(String timeZoneId) {
+    ZoneId zoneId = ZoneId.of(StringUtils.defaultIfBlank(timeZoneId, "UTC"));
+    return Instant.now().atZone(zoneId);
+  }
 
   @Override
   public int hashCode() {

--- a/src/main/java/org/folio/des/scheduling/base/ScheduleDateTimeUtil.java
+++ b/src/main/java/org/folio/des/scheduling/base/ScheduleDateTimeUtil.java
@@ -36,19 +36,25 @@ public final class ScheduleDateTimeUtil {
   }
 
   public static ZonedDateTime convertScheduleTime(Date lastActualExecutionTime, ScheduleParameters scheduleParameters) {
-    ZoneId zoneId = ZoneId.of("UTC");
-    ZonedDateTime startZoneDate = Instant.now().atZone(zoneId);
     if (lastActualExecutionTime != null) {
       Instant instant = Instant.ofEpochMilli(lastActualExecutionTime.getTime());
-      startZoneDate = ZonedDateTime.ofInstant(instant, zoneId);
+      ZoneId zoneId = ZoneId.of("UTC");
+      return ZonedDateTime.ofInstant(instant, zoneId).truncatedTo(ChronoUnit.SECONDS);
+
+    } else if (StringUtils.isNotEmpty(scheduleParameters.getScheduleTime())) {
+      LocalTime localTime = LocalTime.parse(scheduleParameters.getScheduleTime(), DateTimeFormatter.ISO_LOCAL_TIME);
+      ZoneId zoneId =  ZoneId.of(scheduleParameters.getTimeZone());
+      ZonedDateTime startZoneDate = Instant.now().atZone(zoneId);
+      LocalDate nowDate = startZoneDate.toLocalDate();
+      return nowDate.atTime(localTime).atZone(zoneId).truncatedTo(ChronoUnit.SECONDS);
+
     } else {
-      if (StringUtils.isNotEmpty(scheduleParameters.getScheduleTime())) {
-        LocalDate nowDate = startZoneDate.toLocalDate();
-        LocalTime localTime = LocalTime.parse(scheduleParameters.getScheduleTime(), DateTimeFormatter.ISO_LOCAL_TIME);
-        zoneId =  ZoneId.of(scheduleParameters.getTimeZone());
-        return nowDate.atTime(localTime).atZone(zoneId).truncatedTo(ChronoUnit.SECONDS);
-      }
+      return getUtcDateTime().truncatedTo(ChronoUnit.SECONDS);
     }
-    return startZoneDate.truncatedTo(ChronoUnit.SECONDS);
+  }
+
+  private static ZonedDateTime getUtcDateTime() {
+    ZoneId zoneId = ZoneId.of("UTC");
+    return Instant.now().atZone(zoneId);
   }
 }

--- a/src/main/java/org/folio/des/service/JobService.java
+++ b/src/main/java/org/folio/des/service/JobService.java
@@ -13,6 +13,9 @@ public interface JobService {
 
   Job upsert(Job job, boolean withJobCommandSend);
 
+  /**
+   * Deletes old jobs.
+   */
   void deleteOldJobs();
 
 }

--- a/src/main/java/org/folio/des/service/JobService.java
+++ b/src/main/java/org/folio/des/service/JobService.java
@@ -7,11 +7,32 @@ import java.util.UUID;
 
 public interface JobService {
 
+  /**
+   * Gets job by id.
+   *
+   * @param id the job id
+   * @return job by id
+   */
   Job get(UUID id);
 
+  /**
+   * Gets job collection by search query.
+   *
+   * @param offset the offset
+   * @param limit the limit
+   * @param query the query
+   * @return job collection
+   */
   JobCollection get(Integer offset, Integer limit, String query);
 
-  Job upsert(Job job, boolean withJobCommandSend);
+  /**
+   * Inserts or updates job, if @withJobCommandSend enabled - send job to kafka
+   *
+   * @param job the job to upsert
+   * @param withJobCommandSend if true - job will be send to kafka or false otherwise
+   * @return updated job
+   */
+  Job upsertAndSendToKafka(Job job, boolean withJobCommandSend);
 
   /**
    * Deletes old jobs.

--- a/src/test/java/org/folio/des/builder/scheduling/BaseScheduledTaskBuilderTest.java
+++ b/src/test/java/org/folio/des/builder/scheduling/BaseScheduledTaskBuilderTest.java
@@ -60,7 +60,7 @@ class BaseScheduledTaskBuilderTest {
     scheduledJob.setType(ediConfig.getType());
     scheduledJob.setIsSystemSource(true);
 
-    Mockito.when(jobServiceMock.upsert(any(), eq(true))).thenReturn(scheduledJob);
+    Mockito.when(jobServiceMock.upsertAndSendToKafka(any(), eq(true))).thenReturn(scheduledJob);
 
     Optional<ScheduledTask> scheduledTask = builder.buildTask(ediConfig);
 
@@ -70,7 +70,7 @@ class BaseScheduledTaskBuilderTest {
 
     Object actJob = actJobFuture.get();
     service.shutdown();
-    verify(jobServiceMock).upsert(any(), eq(true));
+    verify(jobServiceMock).upsertAndSendToKafka(any(), eq(true));
     verify(contextHelperMock).initScope(TENANT);
     verify(contextHelperMock).finishContext();
   }
@@ -98,7 +98,7 @@ class BaseScheduledTaskBuilderTest {
     scheduledJob.setType(ediConfig.getType());
     scheduledJob.setIsSystemSource(true);
 
-    Mockito.when(jobServiceMock.upsert(any(), eq(true))).thenReturn(scheduledJob);
+    Mockito.when(jobServiceMock.upsertAndSendToKafka(any(), eq(true))).thenReturn(scheduledJob);
 
     Optional<ScheduledTask> scheduledTask = builder.buildTask(ediConfig);
     assertNotNull(scheduledTask.get().getJob());
@@ -108,7 +108,7 @@ class BaseScheduledTaskBuilderTest {
 
     Object actJob = actJobFuture.get();
     service.shutdown();
-    verify(jobServiceMock).upsert(any(), eq(true));
+    verify(jobServiceMock).upsertAndSendToKafka(any(), eq(true));
     verify(contextHelperMock).initScope(TENANT);
     verify(contextHelperMock).finishContext();
   }

--- a/src/test/java/org/folio/des/builder/scheduling/EdifactScheduledTaskBuilderTest.java
+++ b/src/test/java/org/folio/des/builder/scheduling/EdifactScheduledTaskBuilderTest.java
@@ -92,7 +92,7 @@ class EdifactScheduledTaskBuilderTest {
     scheduledJob.setType(ediConfig.getType());
     scheduledJob.setIsSystemSource(true);
 
-    Mockito.when(jobServiceMock.upsert(any(), eq(false))).thenReturn(scheduledJob);
+    Mockito.when(jobServiceMock.upsertAndSendToKafka(any(), eq(false))).thenReturn(scheduledJob);
 
     Optional<ScheduledTask> scheduledTask = builder.buildTask(ediConfig);
 
@@ -102,7 +102,7 @@ class EdifactScheduledTaskBuilderTest {
 
     Object actJob = actJobFuture.get();
     service.shutdown();
-    verify(jobServiceMock).upsert(any(), eq(false));
+    verify(jobServiceMock).upsertAndSendToKafka(any(), eq(false));
     verify(contextHelperMock).initScope(TENANT);
     verify(contextHelperMock).finishContext();
   }
@@ -129,7 +129,7 @@ class EdifactScheduledTaskBuilderTest {
     scheduledJob.setType(ediConfig.getType());
     scheduledJob.setIsSystemSource(true);
 
-    Mockito.when(jobServiceMock.upsert(any(), eq(false))).thenReturn(scheduledJob);
+    Mockito.when(jobServiceMock.upsertAndSendToKafka(any(), eq(false))).thenReturn(scheduledJob);
 
     Optional<ScheduledTask> scheduledTask = builder.buildTask(ediConfig);
     assertNotNull(scheduledTask.get().getJob());
@@ -139,7 +139,7 @@ class EdifactScheduledTaskBuilderTest {
 
     Object actJob = actJobFuture.get();
     service.shutdown();
-    verify(jobServiceMock).upsert(any(), eq(false));
+    verify(jobServiceMock).upsertAndSendToKafka(any(), eq(false));
     verify(contextHelperMock).initScope(TENANT);
     verify(contextHelperMock).finishContext();
     verify(edifactOrdersJobCommandSchedulerBuilder, times(0)).buildJobCommand(scheduledJob);
@@ -171,7 +171,7 @@ class EdifactScheduledTaskBuilderTest {
 
     JobCommand jobCommand = new JobCommand();
     jobCommand.setId(UUID.randomUUID());
-    Mockito.when(jobServiceMock.upsert(any(), eq(false))).thenReturn(scheduledJob);
+    Mockito.when(jobServiceMock.upsertAndSendToKafka(any(), eq(false))).thenReturn(scheduledJob);
     Mockito.when(edifactOrdersJobCommandSchedulerBuilder.buildJobCommand(scheduledJob)).thenReturn(jobCommand);
     Mockito.doNothing().when(jobExecutionService).sendJobCommand(any());
 
@@ -183,7 +183,7 @@ class EdifactScheduledTaskBuilderTest {
 
     Object actJob = actJobFuture.get();
     service.shutdown();
-    verify(jobServiceMock).upsert(any(), eq(false));
+    verify(jobServiceMock).upsertAndSendToKafka(any(), eq(false));
     verify(contextHelperMock).initScope(TENANT);
     verify(contextHelperMock).finishContext();
     verify(edifactOrdersJobCommandSchedulerBuilder, times(1)).buildJobCommand(any(Job.class));

--- a/src/test/java/org/folio/des/scheduling/acquisition/AcqBaseExportTaskTriggerTest.java
+++ b/src/test/java/org/folio/des/scheduling/acquisition/AcqBaseExportTaskTriggerTest.java
@@ -6,10 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.DayOfWeek;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
@@ -277,7 +274,7 @@ class AcqBaseExportTaskTriggerTest {
    "6, 3, 3",
    "7, 3, 4",
    "3, 0, 3",
-   "3, 3, 0"
+   "3, 3, 1"
   })
   void hourlyScheduleWithHours(int frequency, int addHours, int expDiffHours) {
     ScheduleParameters scheduleParameters = new ScheduleParameters();
@@ -315,7 +312,7 @@ class AcqBaseExportTaskTriggerTest {
     "6, 3, 3",
     "7, 3, 4",
     "3, 0, 3",
-    "3, 3, 0"
+    "3, 3, 1"
   })
   void hourlyScheduleWithHoursAndLastJobStartItCanHappenAfterModuleRestart(int frequency, int addHours, int expDiffHours) {
     ScheduleParameters scheduleParameters = new ScheduleParameters();


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODEXPS-97

## Approach
1. When user chooses date in past - spring scheduler immediately pick ups job to execution, in this PR we set next execution time in future using the following rules:
For example, user selects 13.30 as a start time and current time is 16.10 - next run will be at 16.30
For example, user selects 13.10 as a start time and current time is 16.40 - next run will be at 17.10
2. Fixing issue when EDIFACT job sent twice