### PR TITLE
[MODEXPS-108] - Fixed hourlySchedule tests fail at some hours

### DIFF
--- a/src/test/java/org/folio/des/scheduling/acquisition/AcqBaseExportTaskTriggerTest.java
+++ b/src/test/java/org/folio/des/scheduling/acquisition/AcqBaseExportTaskTriggerTest.java
@@ -54,7 +54,6 @@ class AcqBaseExportTaskTriggerTest {
 
   @Test
   @DisplayName("No jobs are scheduled")
-  @Disabled
   void noneScheduled() {
     ScheduleParameters scheduleParameters = new ScheduleParameters();
     scheduleParameters.setId(UUID.randomUUID());
@@ -70,7 +69,6 @@ class AcqBaseExportTaskTriggerTest {
 
   @Test
   @DisplayName("Is disabled schedule")
-  @Disabled
   void isDisabledSchedule() {
     ScheduleParameters scheduleParameters = new ScheduleParameters();
     scheduleParameters.setId(UUID.randomUUID());
@@ -149,30 +147,15 @@ class AcqBaseExportTaskTriggerTest {
     long diff = TimeUnit.HOURS.convert(diffInMilliseconds, TimeUnit.MILLISECONDS);
     assertEquals(expDiffHours, diff);
 
-    ZonedDateTime nowDateTime2 = Instant.now().atZone(ZoneId.of("UTC")).truncatedTo(ChronoUnit.DAYS).withEarlierOffsetAtOverlap();
-    System.out.println(nowDateTime2);
-    ZonedDateTime nowDateTime = Instant.now().atZone(ZoneId.of("UTC")).truncatedTo(ChronoUnit.DAYS);
-    System.out.println(Instant.now().atZone(ZoneId.of("UTC")));
-    // in uct time zone day won't back to before day
-    // actDateHourLate - Wed Nov 02 01:08:38 UTC 2022
-    // lastInstant - 2022-11-02T00:00:00Z
-    // nowDateTime - 2022-11-01T00:00Z[UTC]
-//    23:00 - 01:09 -> 02
-//    23:00 - 01 -> 01
-    // in +5.00 UCT time zone
-    // nowDateTime - 2022-11-02T00:00Z[UTC]
-    // actDateHourLate - Wed Nov 02 08:22:43 PKT 2022
-    // lastInstant - 2022-11-02T00:00:00Z
-    Instant lastInstant = Instant.ofEpochMilli(actDateHourLate.getTime()).truncatedTo(ChronoUnit.DAYS);
+    ZonedDateTime expDateTime =
+      Instant.now().atZone(ZoneId.of("UTC")).plusHours(expDiffHours).truncatedTo(ChronoUnit.DAYS);
+    Instant lastInstant = Instant.ofEpochMilli(actDate.getTime()).truncatedTo(ChronoUnit.DAYS);
     ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(lastInstant, ZoneId.of("UTC")).truncatedTo(ChronoUnit.DAYS);
-    // When my time zone it works very well
-    assertTrue(nowDateTime.isEqual(zonedDateTime));
-
+    assertTrue(expDateTime.isEqual(zonedDateTime));
   }
 
   @Test
   @DisplayName("Should increase Days and provided time should be changed")
-  @Disabled
   void dailySchedule() {
     int expDiffDays = 3;
     ScheduleParameters scheduleParameters = new ScheduleParameters();
@@ -229,7 +212,6 @@ class AcqBaseExportTaskTriggerTest {
     "SATURDAY",
     "SUNDAY"
   })
-  @Disabled
   public void weeklyTestForEachDay(String weekDay) {
     //Given
     ScheduleParameters scheduleParameters = getScheduleParameters(List.of(weekDay), null);
@@ -250,7 +232,6 @@ class AcqBaseExportTaskTriggerTest {
    * For example, now is Monday 15:00, user selects to schedule on Monday at 14:00 - so scheduling should be triggered after a week
    */
   @Test
-  @Disabled
   public void weeklyTestForTheSameDayAndTimeIsInPast() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -274,7 +255,6 @@ class AcqBaseExportTaskTriggerTest {
    * For example, now is Monday 15:00, user selects to schedule on Monday at 16:00 - so scheduling should be triggered at the same day after a hour
    */
   @Test
-  @Disabled
   public void weeklyTestForTheSameDayAndTimeIsInFuture() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -299,7 +279,6 @@ class AcqBaseExportTaskTriggerTest {
    * For example, now is Wednesday 15:00, user selects to schedule on Monday at 15:00 - so scheduling should be triggered after 5 days
    */
   @Test
-  @Disabled
   public void weeklyTestForDayOfWeekInPast() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -323,7 +302,6 @@ class AcqBaseExportTaskTriggerTest {
    * For example, now is Tuesday 10:00, and user selects Monday, Tuesday and Wednesday at 08:00 - so scheduling should be run on Wednesday
    */
   @Test
-  @Disabled
   public void weeklyTestForMultipleDays() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -350,7 +328,6 @@ class AcqBaseExportTaskTriggerTest {
    * For example, if user selects scheduled frequency - 2, we need to shift scheduling day for 2 weeks
    */
   @Test
-  @Disabled
   public void weeklyTestScheduleOnceAtTwoWeek() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -373,7 +350,6 @@ class AcqBaseExportTaskTriggerTest {
   }
 
   @Test
-  @Disabled
   public void weeklyTestScheduleOnceWithMultipleChosenDaysAndFrequencyWhenDayFromNextWeekChosen() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -397,7 +373,6 @@ class AcqBaseExportTaskTriggerTest {
   }
 
   @Test
-  @Disabled
   public void weeklyTestWhenAllDaysChosen() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -445,16 +420,15 @@ class AcqBaseExportTaskTriggerTest {
   @DisplayName("Hour job scheduled for specific hour, when last time behind current time")
   @ParameterizedTest
   @CsvSource({
-   "1, 3, 1",
-   "2, 3, 1",
-   "4, 3, 1",
-   "5, 3, 2",
-   "6, 3, 3",
-   "7, 3, 4",
-   "3, 0, 3",
-   "3, 3, 1"
+    "1, 3, 1",
+    "2, 3, 1",
+    "4, 3, 1",
+    "5, 3, 2",
+    "6, 3, 3",
+    "7, 3, 4",
+    "3, 0, 3",
+    "3, 3, 1"
   })
-  @Disabled
   void hourlyScheduleWithHours(int frequency, int addHours, int expDiffHours) {
     ScheduleParameters scheduleParameters = new ScheduleParameters();
     scheduleParameters.setId(UUID.randomUUID());
@@ -478,7 +452,7 @@ class AcqBaseExportTaskTriggerTest {
     Instant actInstant = Instant.ofEpochMilli(actDate.getTime());
     ZonedDateTime actZonedDateTime = ZonedDateTime.ofInstant(actInstant, ZoneId.of("UTC"));
     int actHour = actZonedDateTime.getHour();
-    assertEquals(actHour, (nowHour + expDiffHours + addHours) % 24);
+    assertEquals((nowHour + expDiffHours + addHours) % 24, actHour);
   }
 
   @DisplayName("Hour job scheduled for specific hour, when last time behind current time")
@@ -493,7 +467,6 @@ class AcqBaseExportTaskTriggerTest {
     "3, 0, 3",
     "3, 3, 1"
   })
-  @Disabled
   void hourlyScheduleWithHoursAndLastJobStartItCanHappenAfterModuleRestart(int frequency, int addHours, int expDiffHours) {
     ScheduleParameters scheduleParameters = new ScheduleParameters();
     scheduleParameters.setId(UUID.randomUUID());
@@ -501,7 +474,6 @@ class AcqBaseExportTaskTriggerTest {
     scheduleParameters.setSchedulePeriod(SchedulePeriodEnum.HOUR);
     scheduleParameters.setTimeZone("UTC");
 
-    // get todays date time and day
     Calendar calLastJob = Calendar.getInstance();
     calLastJob.add(Calendar.HOUR, -addHours);
     Date lastJobTime = calLastJob.getTime();
@@ -518,9 +490,6 @@ class AcqBaseExportTaskTriggerTest {
     Instant actInstant = Instant.ofEpochMilli(actDate.getTime());
     ZonedDateTime actZonedDateTime = ZonedDateTime.ofInstant(actInstant, ZoneId.of("UTC"));
     int actHour = actZonedDateTime.getHour();
-    // I guess there was problem with calculating hours in 24 hours format makes it confusion 20 + 2 + 4 = 26
-    // instead we need remainder when it would be in 24 hours format (20 + 2 + 4) % 24 = 2
     assertEquals((nowHour + expDiffHours + addHours) % 24, actHour);
-//  okapi trigger data - export test ui with data then look at test
   }
 }

--- a/src/test/java/org/folio/des/scheduling/acquisition/AcqBaseExportTaskTriggerTest.java
+++ b/src/test/java/org/folio/des/scheduling/acquisition/AcqBaseExportTaskTriggerTest.java
@@ -54,6 +54,7 @@ class AcqBaseExportTaskTriggerTest {
 
   @Test
   @DisplayName("No jobs are scheduled")
+  @Disabled
   void noneScheduled() {
     ScheduleParameters scheduleParameters = new ScheduleParameters();
     scheduleParameters.setId(UUID.randomUUID());
@@ -69,6 +70,7 @@ class AcqBaseExportTaskTriggerTest {
 
   @Test
   @DisplayName("Is disabled schedule")
+  @Disabled
   void isDisabledSchedule() {
     ScheduleParameters scheduleParameters = new ScheduleParameters();
     scheduleParameters.setId(UUID.randomUUID());
@@ -147,14 +149,30 @@ class AcqBaseExportTaskTriggerTest {
     long diff = TimeUnit.HOURS.convert(diffInMilliseconds, TimeUnit.MILLISECONDS);
     assertEquals(expDiffHours, diff);
 
+    ZonedDateTime nowDateTime2 = Instant.now().atZone(ZoneId.of("UTC")).truncatedTo(ChronoUnit.DAYS).withEarlierOffsetAtOverlap();
+    System.out.println(nowDateTime2);
     ZonedDateTime nowDateTime = Instant.now().atZone(ZoneId.of("UTC")).truncatedTo(ChronoUnit.DAYS);
+    System.out.println(Instant.now().atZone(ZoneId.of("UTC")));
+    // in uct time zone day won't back to before day
+    // actDateHourLate - Wed Nov 02 01:08:38 UTC 2022
+    // lastInstant - 2022-11-02T00:00:00Z
+    // nowDateTime - 2022-11-01T00:00Z[UTC]
+//    23:00 - 01:09 -> 02
+//    23:00 - 01 -> 01
+    // in +5.00 UCT time zone
+    // nowDateTime - 2022-11-02T00:00Z[UTC]
+    // actDateHourLate - Wed Nov 02 08:22:43 PKT 2022
+    // lastInstant - 2022-11-02T00:00:00Z
     Instant lastInstant = Instant.ofEpochMilli(actDateHourLate.getTime()).truncatedTo(ChronoUnit.DAYS);
     ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(lastInstant, ZoneId.of("UTC")).truncatedTo(ChronoUnit.DAYS);
+    // When my time zone it works very well
     assertTrue(nowDateTime.isEqual(zonedDateTime));
+
   }
 
   @Test
   @DisplayName("Should increase Days and provided time should be changed")
+  @Disabled
   void dailySchedule() {
     int expDiffDays = 3;
     ScheduleParameters scheduleParameters = new ScheduleParameters();
@@ -211,6 +229,7 @@ class AcqBaseExportTaskTriggerTest {
     "SATURDAY",
     "SUNDAY"
   })
+  @Disabled
   public void weeklyTestForEachDay(String weekDay) {
     //Given
     ScheduleParameters scheduleParameters = getScheduleParameters(List.of(weekDay), null);
@@ -231,6 +250,7 @@ class AcqBaseExportTaskTriggerTest {
    * For example, now is Monday 15:00, user selects to schedule on Monday at 14:00 - so scheduling should be triggered after a week
    */
   @Test
+  @Disabled
   public void weeklyTestForTheSameDayAndTimeIsInPast() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -254,6 +274,7 @@ class AcqBaseExportTaskTriggerTest {
    * For example, now is Monday 15:00, user selects to schedule on Monday at 16:00 - so scheduling should be triggered at the same day after a hour
    */
   @Test
+  @Disabled
   public void weeklyTestForTheSameDayAndTimeIsInFuture() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -278,6 +299,7 @@ class AcqBaseExportTaskTriggerTest {
    * For example, now is Wednesday 15:00, user selects to schedule on Monday at 15:00 - so scheduling should be triggered after 5 days
    */
   @Test
+  @Disabled
   public void weeklyTestForDayOfWeekInPast() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -301,6 +323,7 @@ class AcqBaseExportTaskTriggerTest {
    * For example, now is Tuesday 10:00, and user selects Monday, Tuesday and Wednesday at 08:00 - so scheduling should be run on Wednesday
    */
   @Test
+  @Disabled
   public void weeklyTestForMultipleDays() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -327,6 +350,7 @@ class AcqBaseExportTaskTriggerTest {
    * For example, if user selects scheduled frequency - 2, we need to shift scheduling day for 2 weeks
    */
   @Test
+  @Disabled
   public void weeklyTestScheduleOnceAtTwoWeek() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -349,6 +373,7 @@ class AcqBaseExportTaskTriggerTest {
   }
 
   @Test
+  @Disabled
   public void weeklyTestScheduleOnceWithMultipleChosenDaysAndFrequencyWhenDayFromNextWeekChosen() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -372,6 +397,7 @@ class AcqBaseExportTaskTriggerTest {
   }
 
   @Test
+  @Disabled
   public void weeklyTestWhenAllDaysChosen() {
     //Given
     ZonedDateTime scheduledDateTime = getNowTime();
@@ -428,6 +454,7 @@ class AcqBaseExportTaskTriggerTest {
    "3, 0, 3",
    "3, 3, 1"
   })
+  @Disabled
   void hourlyScheduleWithHours(int frequency, int addHours, int expDiffHours) {
     ScheduleParameters scheduleParameters = new ScheduleParameters();
     scheduleParameters.setId(UUID.randomUUID());
@@ -451,7 +478,7 @@ class AcqBaseExportTaskTriggerTest {
     Instant actInstant = Instant.ofEpochMilli(actDate.getTime());
     ZonedDateTime actZonedDateTime = ZonedDateTime.ofInstant(actInstant, ZoneId.of("UTC"));
     int actHour = actZonedDateTime.getHour();
-    assertEquals(actHour, nowHour + expDiffHours + addHours);
+    assertEquals(actHour, (nowHour + expDiffHours + addHours) % 24);
   }
 
   @DisplayName("Hour job scheduled for specific hour, when last time behind current time")
@@ -466,6 +493,7 @@ class AcqBaseExportTaskTriggerTest {
     "3, 0, 3",
     "3, 3, 1"
   })
+  @Disabled
   void hourlyScheduleWithHoursAndLastJobStartItCanHappenAfterModuleRestart(int frequency, int addHours, int expDiffHours) {
     ScheduleParameters scheduleParameters = new ScheduleParameters();
     scheduleParameters.setId(UUID.randomUUID());
@@ -473,6 +501,7 @@ class AcqBaseExportTaskTriggerTest {
     scheduleParameters.setSchedulePeriod(SchedulePeriodEnum.HOUR);
     scheduleParameters.setTimeZone("UTC");
 
+    // get todays date time and day
     Calendar calLastJob = Calendar.getInstance();
     calLastJob.add(Calendar.HOUR, -addHours);
     Date lastJobTime = calLastJob.getTime();
@@ -489,6 +518,9 @@ class AcqBaseExportTaskTriggerTest {
     Instant actInstant = Instant.ofEpochMilli(actDate.getTime());
     ZonedDateTime actZonedDateTime = ZonedDateTime.ofInstant(actInstant, ZoneId.of("UTC"));
     int actHour = actZonedDateTime.getHour();
-    assertEquals(nowHour + expDiffHours + addHours, actHour);
+    // I guess there was problem with calculating hours in 24 hours format makes it confusion 20 + 2 + 4 = 26
+    // instead we need remainder when it would be in 24 hours format (20 + 2 + 4) % 24 = 2
+    assertEquals((nowHour + expDiffHours + addHours) % 24, actHour);
+//  okapi trigger data - export test ui with data then look at test
   }
 }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODEXPS-108

## Approach
I fixed some parts of unit tests which are checking the code unproperly


#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Investigate problem
- [ ] Fixed bug
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.

Tested with UCT 23:00:00
![image](https://user-images.githubusercontent.com/113523904/199957761-2ad18693-c0ff-45c0-841a-4512b2c60bc4.png)

