### PR TITLE
[MODEXPS-171] Relase R3 2022 Nolana 1.5.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+## 2022-11-21 v1.5.2
+
+[Full Changelog](https://github.com/folio-org/mod-data-export-spring/compare/v1.5.1...v1.5.2)
+
+### Technical tasks
+* [MODEXPS-170](https://issues.folio.org/browse/MODEXPS-170) Remove redundant dependency from RMB package
+
 ## 2022-11-11 v1.5.1
 
 [Full Changelog](https://github.com/folio-org/mod-data-export-spring/compare/v1.5.0...v1.5.1)

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
 
         <folio-spring-base.version>5.0.1</folio-spring-base.version>
         <hibernate-types-52.version>2.10.3</hibernate-types-52.version>
-        <cql2pgjson.version>34.0.0</cql2pgjson.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <openapi-generator.version>4.3.1</openapi-generator.version>
 
@@ -135,15 +134,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.folio</groupId>
-            <artifactId>cql2pgjson</artifactId>
-            <version>${cql2pgjson.version}</version>
+          <groupId>com.fasterxml.jackson.datatype</groupId>
+          <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-      </dependency>
 
         <!-- Test dependencies -->
         <dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/MODEXPS-171

Some standartized Log4j configuration has been enabled for all modules on Nolana Bugfest env, it has these properties in layout:

[$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}]

that causes mod-data-export-spring application to fail writing logs properly.

To fix it need to delete unnecessary dependency from RMB package