### PR TITLE
MODEXPS-181: mockserver 5.14.0 for arm64 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <version>5.13.2</version>
+            <version>5.14.0</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/org/folio/des/InstallUpgradeIT.java
+++ b/src/test/java/org/folio/des/InstallUpgradeIT.java
@@ -44,6 +44,9 @@ class InstallUpgradeIT {
 
   private static final Logger LOG = LoggerFactory.getLogger(InstallUpgradeIT.class);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final DockerImageName MOCKSERVER_IMAGE = DockerImageName
+    .parse("mockserver/mockserver")
+    .withTag("mockserver-" + MockServerClient.class.getPackage().getImplementationVersion());
   private static final Network NETWORK = Network.newNetwork();
 
   @Container
@@ -65,7 +68,7 @@ class InstallUpgradeIT {
 
   @Container
   private static final MockServerContainer OKAPI =
-    new MockServerContainer(DockerImageName.parse("mockserver/mockserver:mockserver-5.13.2"))
+    new MockServerContainer(MOCKSERVER_IMAGE)
     .withNetwork(NETWORK)
     .withNetworkAliases("okapi")
     .withExposedPorts(1080);


### PR DESCRIPTION
Upgrade mockserver from 5.13.2 to 5.14.0.

Use the mockserver client version for the mockserver server image version as suggested on https://www.testcontainers.org/modules/mockserver/

mockserver 5.14.0 is the first that supports arm64 architecture: https://hub.docker.com/r/mockserver/mockserver/tags