### PR TITLE
MODEXPS-187 Authority control: add new export type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
                             <generateApiDocumentation>true</generateApiDocumentation>
                             <generateModels>true</generateModels>
                             <modelsToGenerate>
-                               BursarFeeFinesTypeMapping,BursarFeeFines,EdiConfig,Edi,EdiSchedule,ScheduleParameters,EdiEmail,EdiFtp,VendorEdiOrdersExportConfig,ExportTypeSpecificParameters,ExportConfig,ExportConfigCollection,EHoldingsExportConfig
+                               BursarFeeFinesTypeMapping,BursarFeeFines,EdiConfig,Edi,EdiSchedule,ScheduleParameters,EdiEmail,EdiFtp,VendorEdiOrdersExportConfig,ExportTypeSpecificParameters,ExportConfig,ExportConfigCollection,EHoldingsExportConfig,AuthorityControlExportConfig
                             </modelsToGenerate>
                             <generateModelTests>false</generateModelTests>
                             <generateSupportingFiles>true</generateSupportingFiles>

--- a/src/main/java/org/folio/des/builder/job/AuthorityControlJobCommandBuilder.java
+++ b/src/main/java/org/folio/des/builder/job/AuthorityControlJobCommandBuilder.java
@@ -1,0 +1,31 @@
+package org.folio.des.builder.job;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.de.entity.Job;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.stereotype.Service;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class AuthorityControlJobCommandBuilder implements JobCommandBuilder {
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public JobParameters buildJobCommand(Job job) {
+    Map<String, JobParameter> params = new HashMap<>();
+    try {
+      params.put("authorityControlExportConfig",
+        new JobParameter(objectMapper.writeValueAsString(job.getExportTypeSpecificParameters().getAuthorityControlExportConfig())));
+      return new JobParameters(params);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/src/main/java/org/folio/des/config/ServiceConfiguration.java
+++ b/src/main/java/org/folio/des/config/ServiceConfiguration.java
@@ -128,7 +128,6 @@ public class ServiceConfiguration {
     converters.put(ExportType.EDIFACT_ORDERS_EXPORT, edifactOrdersJobCommandBuilder);
     converters.put(ExportType.E_HOLDINGS, eHoldingsJobCommandBuilder);
     converters.put(ExportType.AUTH_HEADINGS_UPDATES, authorityControlJobCommandBuilder);
-    converters.put(ExportType.FAILED_LINKED_BIB_UPDATES, authorityControlJobCommandBuilder);
     return new JobCommandBuilderResolver(converters);
   }
 

--- a/src/main/java/org/folio/des/config/ServiceConfiguration.java
+++ b/src/main/java/org/folio/des/config/ServiceConfiguration.java
@@ -3,6 +3,7 @@ package org.folio.des.config;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.folio.des.builder.job.AuthorityControlJobCommandBuilder;
 import org.folio.des.builder.job.BulkEditQueryJobCommandBuilder;
 import org.folio.des.builder.job.BurSarFeeFinesJobCommandBuilder;
 import org.folio.des.builder.job.CirculationLogJobCommandBuilder;
@@ -118,13 +119,16 @@ public class ServiceConfiguration {
                           BurSarFeeFinesJobCommandBuilder burSarFeeFinesJobCommandBuilder,
                           CirculationLogJobCommandBuilder circulationLogJobCommandBuilder,
                           EdifactOrdersJobCommandBuilder edifactOrdersJobCommandBuilder,
-                          EHoldingsJobCommandBuilder eHoldingsJobCommandBuilder) {
+                          EHoldingsJobCommandBuilder eHoldingsJobCommandBuilder,
+                          AuthorityControlJobCommandBuilder authorityControlJobCommandBuilder) {
     Map<ExportType, JobCommandBuilder> converters = new HashMap<>();
     converters.put(ExportType.BULK_EDIT_QUERY, bulkEditQueryJobCommandBuilder);
     converters.put(ExportType.BURSAR_FEES_FINES, burSarFeeFinesJobCommandBuilder);
     converters.put(ExportType.CIRCULATION_LOG, circulationLogJobCommandBuilder);
     converters.put(ExportType.EDIFACT_ORDERS_EXPORT, edifactOrdersJobCommandBuilder);
     converters.put(ExportType.E_HOLDINGS, eHoldingsJobCommandBuilder);
+    converters.put(ExportType.AUTH_HEADINGS_UPDATES, authorityControlJobCommandBuilder);
+    converters.put(ExportType.FAILED_LINKED_BIB_UPDATES, authorityControlJobCommandBuilder);
     return new JobCommandBuilderResolver(converters);
   }
 

--- a/src/main/java/org/folio/des/controller/ControllerExceptionHandler.java
+++ b/src/main/java/org/folio/des/controller/ControllerExceptionHandler.java
@@ -11,6 +11,7 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -30,6 +31,7 @@ public class ControllerExceptionHandler {
     HttpMessageNotReadableException.class,
     MissingServletRequestParameterException.class,
     MethodArgumentTypeMismatchException.class,
+    MethodArgumentNotValidException.class,
     FeignException.class
   })
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/org/folio/des/controller/JobsController.java
+++ b/src/main/java/org/folio/des/controller/JobsController.java
@@ -80,7 +80,7 @@ public class JobsController implements JobsApi {
     var acConfig = exportTypeParameters.getAuthorityControlExportConfig();
 
     return (AUTH_HEADINGS_UPDATES == job.getType() || FAILED_LINKED_BIB_UPDATES == job.getType())
-      && (isNull(acConfig.getFromDate()) || isNull(acConfig.getToDate()) || acConfig.getFromDate().isAfter(acConfig.getToDate()));
+      && acConfig.getFromDate().isAfter(acConfig.getToDate());
   }
 
 }

--- a/src/main/java/org/folio/des/controller/JobsController.java
+++ b/src/main/java/org/folio/des/controller/JobsController.java
@@ -4,8 +4,6 @@ import static java.util.Objects.isNull;
 import static org.folio.des.domain.dto.ExportType.AUTH_HEADINGS_UPDATES;
 import static org.folio.des.domain.dto.ExportType.BULK_EDIT_IDENTIFIERS;
 import static org.folio.des.domain.dto.ExportType.BULK_EDIT_QUERY;
-import static org.folio.des.domain.dto.ExportType.E_HOLDINGS;
-import static org.folio.des.domain.dto.ExportType.FAILED_LINKED_BIB_UPDATES;
 import static org.hibernate.internal.util.StringHelper.isBlank;
 
 import java.util.UUID;
@@ -69,10 +67,8 @@ public class JobsController implements JobsApi {
 
   private boolean isMissingRequiredParameters(Job job) {
     var exportTypeParameters = job.getExportTypeSpecificParameters();
-    var eHoldingsExportConfig = exportTypeParameters.geteHoldingsExportConfig();
     return (BULK_EDIT_QUERY == job.getType() && (isNull(job.getEntityType()) || isBlank(exportTypeParameters.getQuery()))) ||
       (BULK_EDIT_IDENTIFIERS == job.getType() && (isNull(job.getIdentifierType()) || isNull(job.getEntityType()))) ||
-      (E_HOLDINGS == job.getType() && (isNull(eHoldingsExportConfig.getRecordId()) || isNull(eHoldingsExportConfig.getRecordType()))) ||
       invalidAuthorityControlJob(job, exportTypeParameters);
   }
 

--- a/src/main/java/org/folio/des/controller/JobsController.java
+++ b/src/main/java/org/folio/des/controller/JobsController.java
@@ -79,8 +79,7 @@ public class JobsController implements JobsApi {
   private boolean invalidAuthorityControlJob(Job job, ExportTypeSpecificParameters exportTypeParameters) {
     var acConfig = exportTypeParameters.getAuthorityControlExportConfig();
 
-    return (AUTH_HEADINGS_UPDATES == job.getType() || FAILED_LINKED_BIB_UPDATES == job.getType())
-      && acConfig.getFromDate().isAfter(acConfig.getToDate());
+    return AUTH_HEADINGS_UPDATES == job.getType() && acConfig.getFromDate().isAfter(acConfig.getToDate());
   }
 
 }

--- a/src/main/java/org/folio/des/controller/JobsController.java
+++ b/src/main/java/org/folio/des/controller/JobsController.java
@@ -1,9 +1,11 @@
 package org.folio.des.controller;
 
 import static java.util.Objects.isNull;
+import static org.folio.des.domain.dto.ExportType.AUTH_HEADINGS_UPDATES;
 import static org.folio.des.domain.dto.ExportType.BULK_EDIT_IDENTIFIERS;
 import static org.folio.des.domain.dto.ExportType.BULK_EDIT_QUERY;
 import static org.folio.des.domain.dto.ExportType.E_HOLDINGS;
+import static org.folio.des.domain.dto.ExportType.FAILED_LINKED_BIB_UPDATES;
 import static org.hibernate.internal.util.StringHelper.isBlank;
 
 import java.util.UUID;
@@ -12,6 +14,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
+import org.folio.des.domain.dto.ExportTypeSpecificParameters;
 import org.folio.des.domain.dto.Job;
 import org.folio.des.domain.dto.JobCollection;
 import org.folio.des.rest.resource.JobsApi;
@@ -69,7 +72,15 @@ public class JobsController implements JobsApi {
     var eHoldingsExportConfig = exportTypeParameters.geteHoldingsExportConfig();
     return (BULK_EDIT_QUERY == job.getType() && (isNull(job.getEntityType()) || isBlank(exportTypeParameters.getQuery()))) ||
       (BULK_EDIT_IDENTIFIERS == job.getType() && (isNull(job.getIdentifierType()) || isNull(job.getEntityType()))) ||
-      (E_HOLDINGS == job.getType() && (isNull(eHoldingsExportConfig.getRecordId()) || isNull(eHoldingsExportConfig.getRecordType())));
+      (E_HOLDINGS == job.getType() && (isNull(eHoldingsExportConfig.getRecordId()) || isNull(eHoldingsExportConfig.getRecordType()))) ||
+      invalidAuthorityControlJob(job, exportTypeParameters);
+  }
+
+  private boolean invalidAuthorityControlJob(Job job, ExportTypeSpecificParameters exportTypeParameters) {
+    var acConfig = exportTypeParameters.getAuthorityControlExportConfig();
+
+    return (AUTH_HEADINGS_UPDATES == job.getType() || FAILED_LINKED_BIB_UPDATES == job.getType())
+      && (isNull(acConfig.getFromDate()) || isNull(acConfig.getToDate()) || acConfig.getFromDate().isAfter(acConfig.getToDate()));
   }
 
 }

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -8,4 +8,5 @@
   <include file="changes/db.changelog-1.3.0.xml" relativeToChangelogFile="true"/>
   <include file="changes/db.changelog-1.4.0.xml" relativeToChangelogFile="true"/>
   <include file="changes/db.changelog-1.5.0.xml" relativeToChangelogFile="true"/>
+  <include file="changes/db.changelog-1.6.0.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/db.changelog-1.6.0.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.6.0.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="MODEXPS-187@@authority control export" author="viacheslav_kolesnyk">
+    <sql dbms="postgresql">
+      ALTER TYPE ExportType ADD VALUE 'AUTH_HEADINGS_UPDATES';
+      ALTER TYPE ExportType ADD VALUE 'FAILED_LINKED_BIB_UPDATES';
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/folio/des/builder/job/AuthorityControlJobCommandBuilderTest.java
+++ b/src/test/java/org/folio/des/builder/job/AuthorityControlJobCommandBuilderTest.java
@@ -1,0 +1,36 @@
+package org.folio.des.builder.job;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.folio.de.entity.Job;
+import org.folio.des.domain.dto.ExportTypeSpecificParameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthorityControlJobCommandBuilderTest {
+  @Mock
+  ObjectMapper objectMapper;
+  @InjectMocks
+  AuthorityControlJobCommandBuilder authorityControlJobCommandBuilder;
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void shouldHandleJsonProcessingException() throws JsonProcessingException {
+    var params = new ExportTypeSpecificParameters();
+    var job = new Job();
+    job.setExportTypeSpecificParameters(params);
+
+    doThrow(new JsonMappingException("")).when(objectMapper).writeValueAsString(any());
+
+    assertThrows(IllegalArgumentException.class, () -> authorityControlJobCommandBuilder.buildJobCommand(job));
+  }
+}

--- a/src/test/java/org/folio/des/builder/job/AuthorityControlJobCommandBuilderTest.java
+++ b/src/test/java/org/folio/des/builder/job/AuthorityControlJobCommandBuilderTest.java
@@ -16,7 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class AuthorityControlJobCommandBuilderTest {
+class AuthorityControlJobCommandBuilderTest {
   @Mock
   ObjectMapper objectMapper;
   @InjectMocks

--- a/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
+++ b/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
@@ -44,13 +44,18 @@ class JobCommandBuilderResolverTest {
     "BULK_EDIT_QUERY, BulkEditQueryJobCommandBuilder",
     "EDIFACT_ORDERS_EXPORT, EdifactOrdersJobCommandBuilder",
     "E_HOLDINGS, EHoldingsJobCommandBuilder",
-    "AUTH_HEADINGS_UPDATES, AuthorityControlJobCommandBuilder",
-    "FAILED_LINKED_BIB_UPDATES, AuthorityControlJobCommandBuilder"
+    "AUTH_HEADINGS_UPDATES, AuthorityControlJobCommandBuilder"
   })
   void shouldRetrieveBuilderForSpecifiedExportTypeIfBuilderIsRegisteredInTheResolver(ExportType exportType,
               String expBuilderClass) {
     Optional<JobCommandBuilder> builder = resolver.resolve(exportType);
     assertEquals(expBuilderClass, builder.get().getClass().getSimpleName());
+  }
+
+  @Test
+  void shouldNotRetrieveBuilderForFailedLinkedBibUpdates() {
+    Optional<JobCommandBuilder> builder = resolver.resolve(ExportType.FAILED_LINKED_BIB_UPDATES);
+    assertTrue(builder.isEmpty());
   }
 
   @Test
@@ -68,8 +73,7 @@ class JobCommandBuilderResolverTest {
     "BULK_EDIT_QUERY, query",
     "EDIFACT_ORDERS_EXPORT, edifactOrdersExport",
     "E_HOLDINGS, eHoldingsExportConfig",
-    "AUTH_HEADINGS_UPDATES, authorityControlExportConfig",
-    "FAILED_LINKED_BIB_UPDATES, authorityControlExportConfig"
+    "AUTH_HEADINGS_UPDATES, authorityControlExportConfig"
   })
   void shouldBeCreateJobParameters(ExportType exportType, String paramsKey) {
     Optional<JobCommandBuilder> builder = resolver.resolve(exportType);

--- a/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
+++ b/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
@@ -1,18 +1,24 @@
 package org.folio.des.builder.job;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collections;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
+import org.folio.de.entity.Job;
 import org.folio.des.client.ConfigurationClient;
 import org.folio.des.config.JacksonConfiguration;
 import org.folio.des.config.ServiceConfiguration;
-import org.folio.des.domain.dto.*;
-import org.folio.de.entity.Job;
+import org.folio.des.domain.dto.AuthorityControlExportConfig;
+import org.folio.des.domain.dto.BursarFeeFines;
+import org.folio.des.domain.dto.EHoldingsExportConfig;
+import org.folio.des.domain.dto.EntityType;
+import org.folio.des.domain.dto.ExportType;
+import org.folio.des.domain.dto.ExportTypeSpecificParameters;
+import org.folio.des.domain.dto.VendorEdiOrdersExportConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,7 +43,9 @@ class JobCommandBuilderResolverTest {
     "CIRCULATION_LOG, CirculationLogJobCommandBuilder",
     "BULK_EDIT_QUERY, BulkEditQueryJobCommandBuilder",
     "EDIFACT_ORDERS_EXPORT, EdifactOrdersJobCommandBuilder",
-    "E_HOLDINGS, EHoldingsJobCommandBuilder"
+    "E_HOLDINGS, EHoldingsJobCommandBuilder",
+    "AUTH_HEADINGS_UPDATES, AuthorityControlJobCommandBuilder",
+    "FAILED_LINKED_BIB_UPDATES, AuthorityControlJobCommandBuilder"
   })
   void shouldRetrieveBuilderForSpecifiedExportTypeIfBuilderIsRegisteredInTheResolver(ExportType exportType,
               String expBuilderClass) {
@@ -59,7 +67,9 @@ class JobCommandBuilderResolverTest {
     "CIRCULATION_LOG, query",
     "BULK_EDIT_QUERY, query",
     "EDIFACT_ORDERS_EXPORT, edifactOrdersExport",
-    "E_HOLDINGS, eHoldingsExportConfig"
+    "E_HOLDINGS, eHoldingsExportConfig",
+    "AUTH_HEADINGS_UPDATES, authorityControlExportConfig",
+    "FAILED_LINKED_BIB_UPDATES, authorityControlExportConfig"
   })
   void shouldBeCreateJobParameters(ExportType exportType, String paramsKey) {
     Optional<JobCommandBuilder> builder = resolver.resolve(exportType);
@@ -68,6 +78,7 @@ class JobCommandBuilderResolverTest {
     VendorEdiOrdersExportConfig vendorEdiOrdersExportConfig = new VendorEdiOrdersExportConfig();
     EHoldingsExportConfig eHoldingsExportConfig = new EHoldingsExportConfig();
     BursarFeeFines bursarFeeFines = new BursarFeeFines();
+    AuthorityControlExportConfig authorityControlExportConfig = new AuthorityControlExportConfig();
 
     bursarFeeFines.setDaysOutstanding(1);
     bursarFeeFines.addPatronGroupsItem("Test");
@@ -81,15 +92,20 @@ class JobCommandBuilderResolverTest {
     eHoldingsExportConfig.setPackageFields(List.of("packageField"));
     eHoldingsExportConfig.setTitleFields(List.of("titleField"));
 
+    authorityControlExportConfig.setFromDate(LocalDate.now());
+    authorityControlExportConfig.toDate(LocalDate.now());
+
     exportTypeSpecificParameters.setQuery("TestQuery");
     exportTypeSpecificParameters.setBursarFeeFines(bursarFeeFines);
+    exportTypeSpecificParameters.setVendorEdiOrdersExportConfig(vendorEdiOrdersExportConfig);
     exportTypeSpecificParameters.seteHoldingsExportConfig(eHoldingsExportConfig);
+    exportTypeSpecificParameters.setAuthorityControlExportConfig(authorityControlExportConfig);
 
     job.setEntityType(EntityType.USER);
     job.setExportTypeSpecificParameters(exportTypeSpecificParameters);
 
     JobParameters jobParameters = builder.get().buildJobCommand(job);
 
-    assertTrue(jobParameters.getParameters().containsKey(paramsKey));
+    assertNotEquals("null", jobParameters.getParameters().get(paramsKey).getValue());
   }
 }

--- a/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
+++ b/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
@@ -165,7 +165,7 @@ class ConfigsControllerTest extends BaseTest {
                 .headers(defaultHeaders())
                 .content(UPDATE_CONFIG_REQUEST_FAILED))
         .andExpect(
-          matchAll(status().isInternalServerError(),
+          matchAll(status().isBadRequest(),
             content().contentType(MediaType.APPLICATION_JSON_VALUE),
             jsonPath("$.errors[0].type", is("MethodArgumentNotValidException"))));
   }

--- a/src/test/java/org/folio/des/service/JobExecutionServiceTest.java
+++ b/src/test/java/org/folio/des/service/JobExecutionServiceTest.java
@@ -1,0 +1,2 @@
+package org.folio.des.service;public class JobExecutionServiceTest {
+}

--- a/src/test/java/org/folio/des/service/JobExecutionServiceTest.java
+++ b/src/test/java/org/folio/des/service/JobExecutionServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class JobExecutionServiceTest {
+class JobExecutionServiceTest {
 
   @Mock
   private JobCommandBuilderResolver jobCommandBuilderResolver;

--- a/src/test/java/org/folio/des/service/JobExecutionServiceTest.java
+++ b/src/test/java/org/folio/des/service/JobExecutionServiceTest.java
@@ -1,2 +1,35 @@
-package org.folio.des.service;public class JobExecutionServiceTest {
+package org.folio.des.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import org.folio.de.entity.Job;
+import org.folio.des.builder.job.JobCommandBuilderResolver;
+import org.folio.des.domain.dto.ExportType;
+import org.folio.des.validator.ExportConfigValidatorResolver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class JobExecutionServiceTest {
+
+  @Mock
+  private JobCommandBuilderResolver jobCommandBuilderResolver;
+  @Mock
+  private ExportConfigValidatorResolver exportConfigValidatorResolver;
+  @InjectMocks
+  private JobExecutionService jobExecutionService;
+
+  @Test
+  void shouldPrepareStartJobCommandWithNoJobCommandBuilder() {
+    var job = new Job();
+    job.setType(ExportType.FAILED_LINKED_BIB_UPDATES);
+
+    var command = jobExecutionService.prepareStartJobCommand(job);
+
+    assertEquals(new HashMap<>(), command.getJobParameters().getParameters());
+  }
 }


### PR DESCRIPTION
## Purpose
Add Authority control export functionality

## Approach
- update folio-export-common
- add new command builder
- add converters to builder resolver
- add job parameters validation

## Learning
[MODEXPS-187](https://issues.folio.org/browse/MODEXPS-187)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
 
