### PR TITLE
MODEXPS-185 initial setup for introducing Quartz as a scheduler (disabled)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.5</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -106,6 +106,11 @@
           <artifactId>spring-boot-starter-logging</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-quartz</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/des/config/quartz/QuartzSchedulerFactoryBeanCustomizer.java
+++ b/src/main/java/org/folio/des/config/quartz/QuartzSchedulerFactoryBeanCustomizer.java
@@ -1,0 +1,22 @@
+package org.folio.des.config.quartz;
+
+import org.folio.spring.config.DataSourceFolioWrapper;
+import org.springframework.boot.autoconfigure.quartz.SchedulerFactoryBeanCustomizer;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class QuartzSchedulerFactoryBeanCustomizer implements SchedulerFactoryBeanCustomizer {
+  private final DataSourceFolioWrapper dataSourceFolioWrapper;
+
+  /**
+   * Use plain datasource instead of folio wrapper for quartz since it does not need tenant specific schemas logic
+   */
+  @Override
+  public void customize(SchedulerFactoryBean schedulerFactoryBean) {
+    schedulerFactoryBean.setDataSource(dataSourceFolioWrapper.getTargetDataSource());
+  }
+}

--- a/src/main/java/org/folio/des/config/quartz/QuartzSchemaInitializer.java
+++ b/src/main/java/org/folio/des/config/quartz/QuartzSchemaInitializer.java
@@ -34,7 +34,7 @@ public class QuartzSchemaInitializer implements InitializingBean {
   @Override
   public void afterPropertiesSet() throws LiquibaseException {
     if (!quartzEnabled) {
-      log.info("Quartz scheduling is disabled. Schema liquibase initialization is skipped");
+      log.info("Quartz scheduling is disabled. Schema liquibase initialization for quartz is skipped");
       return;
     }
     folioSpringLiquibase.setChangeLog(quartzChangeLog);

--- a/src/main/java/org/folio/des/config/quartz/QuartzSchemaInitializer.java
+++ b/src/main/java/org/folio/des/config/quartz/QuartzSchemaInitializer.java
@@ -1,0 +1,48 @@
+package org.folio.des.config.quartz;
+
+import org.folio.spring.liquibase.FolioSpringLiquibase;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties;
+import org.springframework.stereotype.Component;
+
+import liquibase.exception.LiquibaseException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class QuartzSchemaInitializer implements InitializingBean {
+  private final LiquibaseProperties liquibaseProperties;
+  private final FolioSpringLiquibase folioSpringLiquibase;
+
+  @Value("${folio.quartz.enabled}")
+  private boolean quartzEnabled;
+
+  @Value("${folio.quartz.schemaName}")
+  private String quartzSchemaName;
+
+  @Value("${folio.quartz.changeLog}")
+  private String quartzChangeLog;
+
+  /**
+   * Performs database update using {@link FolioSpringLiquibase} and then returns previous configuration for this bean.
+   *
+   * @throws LiquibaseException - if liquibase update failed.
+   */
+  @Override
+  public void afterPropertiesSet() throws LiquibaseException {
+    if (!quartzEnabled) {
+      log.info("Quartz scheduling is disabled. Schema liquibase initialization is skipped");
+      return;
+    }
+    folioSpringLiquibase.setChangeLog(quartzChangeLog);
+    folioSpringLiquibase.setDefaultSchema(quartzSchemaName);
+
+    folioSpringLiquibase.performLiquibaseUpdate();
+
+    folioSpringLiquibase.setChangeLog(liquibaseProperties.getChangeLog());
+    folioSpringLiquibase.setDefaultSchema(liquibaseProperties.getDefaultSchema());
+  }
+}

--- a/src/main/java/org/folio/des/scheduling/quartz/QuartzExportJobScheduler.java
+++ b/src/main/java/org/folio/des/scheduling/quartz/QuartzExportJobScheduler.java
@@ -1,0 +1,94 @@
+package org.folio.des.scheduling.quartz;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.folio.des.domain.dto.ExportConfig;
+import org.folio.des.domain.dto.ExportConfig.SchedulePeriodEnum;
+import org.folio.des.domain.dto.Job;
+import org.folio.des.scheduling.ExportJobScheduler;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
+import org.springframework.core.convert.converter.Converter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Draft of quartz {@link ExportJobScheduler} implementation
+ */
+@RequiredArgsConstructor
+@Log4j2
+public class QuartzExportJobScheduler implements ExportJobScheduler {
+  private final Scheduler scheduler;
+  // will be Converter<ExportConfig, List<Trigger>> if it'll be needed to set up several triggers for same job
+  private final Converter<ExportConfig, Trigger> triggerConverter;
+  private final Converter<ExportConfig, JobDetail> jobDetailConverter;
+
+  @Override
+  @SneakyThrows
+  public List<Job> scheduleExportJob(ExportConfig exportConfig) {
+    if (scheduleExists(exportConfig)) {
+      rescheduleJob(exportConfig);
+    } else {
+      scheduleJob(exportConfig);
+    }
+    // there should be the list of jobs created based on
+    // exportConfig and scheduled/rescheduled
+    return Collections.emptyList();
+  }
+
+  private void scheduleJob(ExportConfig exportConfig) throws SchedulerException {
+    if (!isDisabledSchedule(exportConfig)) {
+      Trigger trigger = buildTrigger(exportConfig);
+      JobDetail jobDetail = buildJobDetail(exportConfig);
+      scheduler.scheduleJob(jobDetail, trigger);
+      log.info("scheduleJob:: job {} with trigger {} scheduled for config id {}", () -> jobDetail.getKey(),
+        () -> trigger.getKey(), () -> exportConfig.getId());
+    } else {
+      log.info("scheduleJob:: schedule is disabled for config id {}", () -> exportConfig.getId());
+    }
+  }
+
+  private void rescheduleJob(ExportConfig exportConfig) throws SchedulerException {
+    if (isDisabledSchedule(exportConfig)) {
+      JobKey jobKey = getJobKey(exportConfig);
+      scheduler.deleteJob(jobKey);
+      log.info("rescheduleJob:: job {} deleted for config id {}", () -> jobKey, () -> exportConfig.getId());
+    } else {
+      TriggerKey triggerKey = getTriggerKey(exportConfig);
+      scheduler.rescheduleJob(triggerKey, buildTrigger(exportConfig));
+      log.info("rescheduleJob:: trigger {} rescheduled for config id {}", () -> triggerKey, () -> exportConfig.getId());
+    }
+  }
+
+  private boolean scheduleExists(ExportConfig exportConfig) throws SchedulerException {
+    return scheduler.checkExists(getTriggerKey(exportConfig));
+  }
+
+  private boolean isDisabledSchedule(ExportConfig exportConfig) {
+    SchedulePeriodEnum schedulePeriod = exportConfig.getSchedulePeriod();
+    return schedulePeriod == null || SchedulePeriodEnum.NONE == exportConfig.getSchedulePeriod();
+  }
+
+  private TriggerKey getTriggerKey(ExportConfig exportConfig) {
+    return TriggerKey.triggerKey(exportConfig.getId());
+  }
+
+  private JobKey getJobKey(ExportConfig exportConfig) {
+    return JobKey.jobKey(exportConfig.getId());
+  }
+
+  private JobDetail buildJobDetail(ExportConfig exportConfig) {
+    return jobDetailConverter.convert(exportConfig);
+  }
+
+  private Trigger buildTrigger(ExportConfig exportConfig) {
+    return triggerConverter.convert(exportConfig);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,10 @@ folio:
     acquisition:
       poolSize: 10
       runOnlyIfModuleRegistered: true
+  quartz:
+    enabled: false
+    schemaName: mod_data_export_spring_quartz
+    changeLog: classpath:db/changelog/changelog-quartz.xml
 server:
   port: 8081
 logging:
@@ -45,6 +49,30 @@ spring:
       continue-on-error: true
   jackson:
     default-property-inclusion: non_null
+  quartz:
+    auto-startup: ${folio.quartz.enabled}
+    job-store-type: jdbc
+    jdbc:
+      initialize-schema: never
+    properties:
+      org.quartz:
+        scheduler:
+          instanceId: AUTO
+        jobStore:
+          driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+          class: org.quartz.impl.jdbcjobstore.JobStoreTX
+          tablePrefix: ${folio.quartz.schemaName}.QRTZ_
+          dataSource: quartz
+          misfireThreshold: 10000
+          isClustered: true
+          clusterCheckinInterval: 15000
+        dataSource:
+          quartz:
+            driver: org.postgresql.Driver
+            provider: hikaricp
+            URL: ${spring.datasource.url}
+            user: ${spring.datasource.username}
+            password: ${spring.datasource.password}
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,21 +58,13 @@ spring:
       org.quartz:
         scheduler:
           instanceId: AUTO
+          instanceName: ModDataExportSpringScheduler
         jobStore:
           driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
-          class: org.quartz.impl.jdbcjobstore.JobStoreTX
           tablePrefix: ${folio.quartz.schemaName}.QRTZ_
-          dataSource: quartz
           misfireThreshold: 10000
           isClustered: true
           clusterCheckinInterval: 15000
-        dataSource:
-          quartz:
-            driver: org.postgresql.Driver
-            provider: hikaricp
-            URL: ${spring.datasource.url}
-            user: ${spring.datasource.username}
-            password: ${spring.datasource.password}
 management:
   endpoints:
     web:

--- a/src/main/resources/db/changelog/changelog-quartz.xml
+++ b/src/main/resources/db/changelog/changelog-quartz.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+  <include file="quartz/initial-schema.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/quartz/initial-schema.xml
+++ b/src/main/resources/db/changelog/quartz/initial-schema.xml
@@ -1,0 +1,358 @@
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <property name="table_prefix" value="QRTZ_"/>
+
+  <property name="blob_type" value="BYTEA" dbms="postgresql"/>
+  <property name="blob_type" value="BLOB"/>
+
+  <changeSet id="quartz-init" author="quartz">
+
+    <createTable tableName="${table_prefix}LOCKS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="LOCK_NAME" type="VARCHAR(40)">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, LOCK_NAME" tableName="${table_prefix}LOCKS"/>
+
+    <createTable tableName="${table_prefix}FIRED_TRIGGERS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="ENTRY_ID" type="VARCHAR(95)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="INSTANCE_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="FIRED_TIME" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="SCHED_TIME" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="PRIORITY" type="INTEGER">
+        <constraints nullable="false"/>
+      </column>
+      <column name="STATE" type="VARCHAR(16)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="JOB_NAME" type="VARCHAR(200)"/>
+      <column name="JOB_GROUP" type="VARCHAR(200)"/>
+      <column name="IS_NONCONCURRENT" type="BOOLEAN"/>
+      <column name="REQUESTS_RECOVERY" type="BOOLEAN"/>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, ENTRY_ID" tableName="${table_prefix}FIRED_TRIGGERS"/>
+
+    <createIndex tableName="${table_prefix}FIRED_TRIGGERS" indexName="IDX_${table_prefix}FT_INST_JOB_REQ_RCVRY">
+      <column name="SCHED_NAME"/>
+      <column name="INSTANCE_NAME"/>
+      <column name="REQUESTS_RECOVERY"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}FIRED_TRIGGERS" indexName="IDX_${table_prefix}FT_J_G">
+      <column name="SCHED_NAME"/>
+      <column name="JOB_NAME"/>
+      <column name="JOB_GROUP"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}FIRED_TRIGGERS" indexName="IDX_${table_prefix}FT_JG">
+      <column name="SCHED_NAME"/>
+      <column name="JOB_GROUP"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}FIRED_TRIGGERS" indexName="IDX_${table_prefix}FT_T_G">
+      <column name="SCHED_NAME"/>
+      <column name="TRIGGER_NAME"/>
+      <column name="TRIGGER_GROUP"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}FIRED_TRIGGERS" indexName="IDX_${table_prefix}FT_TG">
+      <column name="SCHED_NAME"/>
+      <column name="TRIGGER_GROUP"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}FIRED_TRIGGERS" indexName="IDX_${table_prefix}FT_TRIG_INST_NAME">
+      <column name="SCHED_NAME"/>
+      <column name="INSTANCE_NAME"/>
+    </createIndex>
+
+    <createTable tableName="${table_prefix}CALENDARS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="CALENDAR_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="CALENDAR" type="${blob_type}">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, CALENDAR_NAME" tableName="${table_prefix}CALENDARS"/>
+
+    <createTable tableName="${table_prefix}PAUSED_TRIGGER_GRPS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_GROUP" tableName="${table_prefix}PAUSED_TRIGGER_GRPS"/>
+
+    <createTable tableName="${table_prefix}SCHEDULER_STATE">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="INSTANCE_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="LAST_CHECKIN_TIME" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="CHECKIN_INTERVAL" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, INSTANCE_NAME" tableName="${table_prefix}SCHEDULER_STATE"/>
+
+    <createTable tableName="${table_prefix}JOB_DETAILS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="JOB_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="JOB_GROUP" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="DESCRIPTION" type="VARCHAR(250)"/>
+      <column name="JOB_CLASS_NAME" type="VARCHAR(250)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="IS_DURABLE" type="BOOLEAN">
+        <constraints nullable="false"/>
+      </column>
+      <column name="IS_NONCONCURRENT" type="BOOLEAN">
+        <constraints nullable="false"/>
+      </column>
+      <column name="IS_UPDATE_DATA" type="BOOLEAN">
+        <constraints nullable="false"/>
+      </column>
+      <column name="REQUESTS_RECOVERY" type="BOOLEAN">
+        <constraints nullable="false"/>
+      </column>
+      <column name="JOB_DATA" type="${blob_type}"/>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, JOB_NAME, JOB_GROUP" tableName="${table_prefix}JOB_DETAILS"/>
+
+    <createIndex tableName="${table_prefix}JOB_DETAILS" indexName="IDX_${table_prefix}J_GRP">
+      <column name="SCHED_NAME"/>
+      <column name="JOB_GROUP"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}JOB_DETAILS" indexName="IDX_${table_prefix}J_REQ_RECOVERY">
+      <column name="SCHED_NAME"/>
+      <column name="REQUESTS_RECOVERY"/>
+    </createIndex>
+
+    <createTable tableName="${table_prefix}TRIGGERS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="JOB_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="JOB_GROUP" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="DESCRIPTION" type="VARCHAR(250)"/>
+      <column name="NEXT_FIRE_TIME" type="BIGINT"/>
+      <column name="PREV_FIRE_TIME" type="BIGINT"/>
+      <column name="PRIORITY" type="INTEGER"/>
+      <column name="TRIGGER_STATE" type="VARCHAR(16)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_TYPE" type="VARCHAR(8)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="START_TIME" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="END_TIME" type="BIGINT"/>
+      <column name="CALENDAR_NAME" type="VARCHAR(200)"/>
+      <column name="MISFIRE_INSTR" type="smallint"/>
+      <column name="JOB_DATA" type="${blob_type}"/>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="${table_prefix}TRIGGERS"/>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_C">
+      <column name="SCHED_NAME"/>
+      <column name="CALENDAR_NAME"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_G">
+      <column name="SCHED_NAME"/>
+      <column name="TRIGGER_GROUP"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_JG">
+      <column name="SCHED_NAME"/>
+      <column name="JOB_GROUP"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_N_G_STATE">
+      <column name="SCHED_NAME"/>
+      <column name="TRIGGER_GROUP"/>
+      <column name="TRIGGER_STATE"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_N_STATE">
+      <column name="SCHED_NAME"/>
+      <column name="TRIGGER_NAME"/>
+      <column name="TRIGGER_GROUP"/>
+      <column name="TRIGGER_STATE"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_NEXT_FIRE_TIME">
+      <column name="SCHED_NAME"/>
+      <column name="NEXT_FIRE_TIME"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_NFT_MISFIRE">
+      <column name="SCHED_NAME"/>
+      <column name="MISFIRE_INSTR"/>
+      <column name="NEXT_FIRE_TIME"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_NFT_ST">
+      <column name="SCHED_NAME"/>
+      <column name="TRIGGER_STATE"/>
+      <column name="NEXT_FIRE_TIME"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_NFT_ST_MISFIRE">
+      <column name="SCHED_NAME"/>
+      <column name="MISFIRE_INSTR"/>
+      <column name="NEXT_FIRE_TIME"/>
+      <column name="TRIGGER_STATE"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_NFT_ST_MISFIRE_GRP">
+      <column name="SCHED_NAME"/>
+      <column name="MISFIRE_INSTR"/>
+      <column name="NEXT_FIRE_TIME"/>
+      <column name="TRIGGER_GROUP"/>
+      <column name="TRIGGER_STATE"/>
+    </createIndex>
+
+    <createIndex tableName="${table_prefix}TRIGGERS" indexName="IDX_${table_prefix}T_STATE">
+      <column name="SCHED_NAME"/>
+      <column name="TRIGGER_STATE"/>
+    </createIndex>
+
+    <createTable tableName="${table_prefix}BLOB_TRIGGERS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="BLOB_DATA" type="${blob_type}"/>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="${table_prefix}BLOB_TRIGGERS"/>
+
+    <createTable tableName="${table_prefix}SIMPROP_TRIGGERS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="STR_PROP_1" type="VARCHAR(512)"/>
+      <column name="STR_PROP_2" type="VARCHAR(512)"/>
+      <column name="STR_PROP_3" type="VARCHAR(512)"/>
+      <column name="INT_PROP_1" type="INTEGER"/>
+      <column name="INT_PROP_2" type="INTEGER"/>
+      <column name="LONG_PROP_1" type="BIGINT"/>
+      <column name="LONG_PROP_2" type="BIGINT"/>
+      <column name="DEC_PROP_1" type="NUMERIC(13,4)"/>
+      <column name="DEC_PROP_2" type="NUMERIC(13,4)"/>
+      <column name="BOOL_PROP_1" type="BOOLEAN"/>
+      <column name="BOOL_PROP_2" type="BOOLEAN"/>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="${table_prefix}SIMPROP_TRIGGERS"/>
+
+    <createTable tableName="${table_prefix}CRON_TRIGGERS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="CRON_EXPRESSION" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TIME_ZONE_ID" type="VARCHAR(80)"/>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="${table_prefix}CRON_TRIGGERS"/>
+
+    <createTable tableName="${table_prefix}SIMPLE_TRIGGERS">
+      <column name="SCHED_NAME" type="VARCHAR(120)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_NAME" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TRIGGER_GROUP" type="VARCHAR(200)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="REPEAT_COUNT" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="REPEAT_INTERVAL" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="TIMES_TRIGGERED" type="BIGINT">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <addPrimaryKey columnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" tableName="${table_prefix}SIMPLE_TRIGGERS"/>
+
+    <addForeignKeyConstraint baseTableName="${table_prefix}TRIGGERS" constraintName="${table_prefix}TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, JOB_NAME, JOB_GROUP" referencedTableName="${table_prefix}JOB_DETAILS" referencedColumnNames="SCHED_NAME, JOB_NAME, JOB_GROUP"/>
+
+    <addForeignKeyConstraint baseTableName="${table_prefix}SIMPLE_TRIGGERS" constraintName="${table_prefix}SIMPLE_TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" referencedTableName="${table_prefix}TRIGGERS" referencedColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP"/>
+
+    <addForeignKeyConstraint baseTableName="${table_prefix}CRON_TRIGGERS" constraintName="${table_prefix}CRON_TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" referencedTableName="${table_prefix}TRIGGERS" referencedColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP"/>
+
+    <addForeignKeyConstraint baseTableName="${table_prefix}SIMPROP_TRIGGERS" constraintName="${table_prefix}SIMPROP_TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" referencedTableName="${table_prefix}TRIGGERS" referencedColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP"/>
+
+    <addForeignKeyConstraint baseTableName="${table_prefix}BLOB_TRIGGERS" constraintName="${table_prefix}BLOB_TRIGGERS_SCHED_NAME_FKEY" baseColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP" referencedTableName="${table_prefix}TRIGGERS" referencedColumnNames="SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
+++ b/src/test/java/org/folio/des/builder/job/JobCommandBuilderResolverTest.java
@@ -27,11 +27,12 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(classes = {JacksonConfiguration.class, ServiceConfiguration.class})
-@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class})
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class JobCommandBuilderResolverTest {
 
   @Autowired

--- a/src/test/java/org/folio/des/converter/ExportConfigConverterResolverTest.java
+++ b/src/test/java/org/folio/des/converter/ExportConfigConverterResolverTest.java
@@ -13,12 +13,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.convert.converter.Converter;
 
 @SpringBootTest(classes = {JacksonConfiguration.class, ServiceConfiguration.class})
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class ExportConfigConverterResolverTest {
 
   @Autowired

--- a/src/test/java/org/folio/des/converter/acquisition/EdifactOrdersExportConfigToTaskTriggerConverterTest.java
+++ b/src/test/java/org/folio/des/converter/acquisition/EdifactOrdersExportConfigToTaskTriggerConverterTest.java
@@ -26,12 +26,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(classes = { JacksonConfiguration.class, ServiceConfiguration.class,
                             EdifactOrdersExportConfigToTaskTriggerConverter.class})
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class EdifactOrdersExportConfigToTaskTriggerConverterTest {
   private static final String ACC_TIME = "17:08:39";
 

--- a/src/test/java/org/folio/des/converter/acquisition/InitEdifactOrdersExportConfigToTaskTriggerConverterTest.java
+++ b/src/test/java/org/folio/des/converter/acquisition/InitEdifactOrdersExportConfigToTaskTriggerConverterTest.java
@@ -35,12 +35,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(classes = { JacksonConfiguration.class, ServiceConfiguration.class,
                             EdifactOrdersExportConfigToTaskTriggerConverter.class})
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class InitEdifactOrdersExportConfigToTaskTriggerConverterTest {
   @Autowired
   private InitEdifactOrdersExportConfigToTaskTriggerConverter converter;

--- a/src/test/java/org/folio/des/scheduling/quartz/QuartzExportJobSchedulerTest.java
+++ b/src/test/java/org/folio/des/scheduling/quartz/QuartzExportJobSchedulerTest.java
@@ -1,0 +1,235 @@
+package org.folio.des.scheduling.quartz;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.folio.des.domain.dto.ExportConfig;
+import org.folio.des.domain.dto.ExportConfig.SchedulePeriodEnum;
+import org.folio.des.support.BaseTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.quartz.listeners.JobListenerSupport;
+import org.quartz.listeners.SchedulerListenerSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.convert.converter.Converter;
+
+import lombok.extern.log4j.Log4j2;
+
+@SpringBootTest(properties = {
+  "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+  "folio.quartz.enabled=true"})
+class QuartzExportJobSchedulerTest extends BaseTest {
+
+  private static final String SCHEDULE_ID = "scheduleId_" + UUID.randomUUID();
+
+  @Autowired
+  private Scheduler scheduler;
+  private QuartzExportJobScheduler quartzExportJobScheduler;
+
+  @BeforeEach
+  void init() {
+    quartzExportJobScheduler = new QuartzExportJobScheduler(scheduler,
+      new TestTriggerConverter(), new TestJobDetailConverter());
+  }
+
+  @AfterEach
+  void afterEach() throws SchedulerException {
+    scheduler.clear();
+  }
+
+  @Test
+  void testSchedule() throws SchedulerException {
+    TestingJobListener jobListener = registerTestingJobListener();
+    TestingSchedulerListener schedulerListener = registerTestingSchedulerListener();
+
+    ExportConfig config = buildExportConfig(SCHEDULE_ID, true);
+    quartzExportJobScheduler.scheduleExportJob(config);
+
+    assertTrue(scheduler.checkExists(JobKey.jobKey(SCHEDULE_ID)));
+    assertEquals(1, schedulerListener.getJobsAddedCount());
+    assertEquals(1, schedulerListener.getJobsScheduledCount());
+
+    await().pollDelay(1, TimeUnit.SECONDS).timeout(5, TimeUnit.SECONDS).untilAsserted(
+      () -> assertEquals(1, jobListener.getJobsExecutedCount()));
+  }
+
+  @Test
+  void testUnschedule() throws SchedulerException {
+    TestingSchedulerListener schedulerListener = registerTestingSchedulerListener();
+
+    ExportConfig config = buildExportConfig(SCHEDULE_ID, true);
+    quartzExportJobScheduler.scheduleExportJob(config);
+
+    // scheduleExportJob with disabled scheduling for existing id should result in job unscheduling
+    ExportConfig disabledConfig = buildExportConfig(SCHEDULE_ID, false);
+    quartzExportJobScheduler.scheduleExportJob(disabledConfig);
+
+    assertFalse(scheduler.checkExists(JobKey.jobKey(SCHEDULE_ID)));
+    assertEquals(1, schedulerListener.getJobsAddedCount());
+    assertEquals(1, schedulerListener.getJobsScheduledCount());
+    assertEquals(1, schedulerListener.getJobsDeletedCount());
+  }
+
+  @Test
+  void testReschedule() throws SchedulerException {
+    TestingSchedulerListener schedulerListener = registerTestingSchedulerListener();
+
+    ExportConfig config = buildExportConfig(SCHEDULE_ID, true);
+    quartzExportJobScheduler.scheduleExportJob(config);
+
+    // scheduleExportJob with enabled scheduling for existing id should result in job rescheduling
+    ExportConfig reschedulingConfig = buildExportConfig(SCHEDULE_ID, true);
+    quartzExportJobScheduler.scheduleExportJob(reschedulingConfig);
+
+    assertTrue(scheduler.checkExists(JobKey.jobKey(SCHEDULE_ID)));
+    assertEquals(1, schedulerListener.getJobsAddedCount());
+    assertEquals(2, schedulerListener.getJobsScheduledCount());
+    assertEquals(1, schedulerListener.getJobsUnscheduledCount());
+  }
+
+  @Test
+  void testScheduleForDisabledConfig() throws SchedulerException {
+    TestingSchedulerListener schedulerListener = registerTestingSchedulerListener();
+
+    ExportConfig config = buildExportConfig(SCHEDULE_ID, false);
+    quartzExportJobScheduler.scheduleExportJob(config);
+
+    assertFalse(scheduler.checkExists(JobKey.jobKey(SCHEDULE_ID)));
+    assertEquals(0, schedulerListener.getJobsScheduledCount());
+  }
+
+  private ExportConfig buildExportConfig(String configId, boolean isEnabled) {
+    return new ExportConfig()
+      .id(configId)
+      .scheduleTime("2024-04-24T11:00Z")
+      .schedulePeriod(isEnabled ? SchedulePeriodEnum.DAY : SchedulePeriodEnum.NONE)
+      .scheduleFrequency(2);
+  }
+
+  private TestingSchedulerListener registerTestingSchedulerListener() throws SchedulerException {
+    TestingSchedulerListener schedulerListener = new TestingSchedulerListener();
+    scheduler.getListenerManager().addSchedulerListener(schedulerListener);
+    return schedulerListener;
+  }
+
+  private TestingJobListener registerTestingJobListener() throws SchedulerException {
+    TestingJobListener jobListener = new TestingJobListener();
+    scheduler.getListenerManager().addJobListener(jobListener);
+    return jobListener;
+  }
+
+  private static class TestTriggerConverter implements Converter<ExportConfig, Trigger> {
+    @Override
+    public Trigger convert(ExportConfig exportConfig) {
+      return TriggerBuilder
+        .newTrigger()
+        .withIdentity(exportConfig.getId())
+        .withSchedule(SimpleScheduleBuilder
+          .simpleSchedule()
+          .withRepeatCount(0))
+        .startAt(Date.from(Instant.now().plus(2, ChronoUnit.SECONDS)))
+        .build();
+    }
+  }
+
+  private static class TestJobDetailConverter implements Converter<ExportConfig, JobDetail> {
+    @Override
+    public JobDetail convert(ExportConfig exportConfig) {
+      return JobBuilder
+        .newJob(DraftJob.class)
+        .withIdentity(exportConfig.getId())
+        .build();
+    }
+  }
+
+  @Log4j2
+  private static class DraftJob implements org.quartz.Job {
+    @Override
+    public void execute(JobExecutionContext context) {
+      log.info("job {} is executing", context.getJobDetail().getKey());
+    }
+  }
+
+  private static class TestingJobListener extends JobListenerSupport {
+    private final AtomicInteger jobsExecutedCount = new AtomicInteger();
+
+    @Override
+    public String getName() {
+      return "TestingJobListener";
+    }
+
+    @Override
+    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+      jobsExecutedCount.incrementAndGet();
+    }
+
+    public int getJobsExecutedCount() {
+      return jobsExecutedCount.get();
+    }
+  }
+
+  private static class TestingSchedulerListener extends SchedulerListenerSupport {
+    private final AtomicInteger jobsAddedCount = new AtomicInteger();
+    private final AtomicInteger jobsDeletedCount = new AtomicInteger();
+    private final AtomicInteger jobsUnscheduledCount = new AtomicInteger();
+    private final AtomicInteger jobsScheduledCount = new AtomicInteger();
+
+    @Override
+    public void jobDeleted(JobKey jobKey) {
+      jobsDeletedCount.incrementAndGet();
+    }
+
+    @Override
+    public void jobUnscheduled(TriggerKey triggerKey) {
+      jobsUnscheduledCount.incrementAndGet();
+    }
+
+    @Override
+    public void jobAdded(JobDetail jobDetail) {
+      jobsAddedCount.incrementAndGet();
+    }
+
+    @Override
+    public void jobScheduled(Trigger trigger) {
+      jobsScheduledCount.incrementAndGet();
+    }
+
+    public int getJobsAddedCount() {
+      return jobsAddedCount.get();
+    }
+
+    public int getJobsDeletedCount() {
+      return jobsDeletedCount.get();
+    }
+
+    public int getJobsUnscheduledCount() {
+      return jobsUnscheduledCount.get();
+    }
+
+    public int getJobsScheduledCount() {
+      return jobsScheduledCount.get();
+    }
+  }
+}

--- a/src/test/java/org/folio/des/service/JobServiceTest.java
+++ b/src/test/java/org/folio/des/service/JobServiceTest.java
@@ -46,10 +46,11 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class JobServiceTest {
   private static final int DEFAULT_JOB_EXPIRATION_PERIOD = 7;
   private static final int DEFAULT_BULK_EDIT_JOB_EXPIRATION_PERIOD = 14;

--- a/src/test/java/org/folio/des/service/config/acquisition/EdifactOrdersExportServiceTest.java
+++ b/src/test/java/org/folio/des/service/config/acquisition/EdifactOrdersExportServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -33,7 +34,7 @@ import static org.mockito.ArgumentMatchers.eq;
 
 @SpringBootTest(classes = {DefaultModelConfigToExportConfigConverter.class, JacksonConfiguration.class,
   ServiceConfiguration.class})
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class EdifactOrdersExportServiceTest {
 
   public static final String EMPTY_CONFIG_RESPONSE = "{\"configs\": [], \"totalRecords\": 0}";

--- a/src/test/java/org/folio/des/service/config/impl/BaseExportConfigServiceTest.java
+++ b/src/test/java/org/folio/des/service/config/impl/BaseExportConfigServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -36,7 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(classes = {DefaultModelConfigToExportConfigConverter.class, JacksonConfiguration.class,
                   ServiceConfiguration.class})
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class BaseExportConfigServiceTest {
 
   public static final String CONFIG_RESPONSE =

--- a/src/test/java/org/folio/des/service/config/impl/BurSarFeesFinesExportConfigServiceTest.java
+++ b/src/test/java/org/folio/des/service/config/impl/BurSarFeesFinesExportConfigServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -36,7 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(classes = {DefaultModelConfigToExportConfigConverter.class, JacksonConfiguration.class,
                   ServiceConfiguration.class})
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class BurSarFeesFinesExportConfigServiceTest {
 
   public static final String CONFIG_RESPONSE =

--- a/src/test/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManagerTest.java
+++ b/src/test/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManagerTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -39,7 +40,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(classes = { ServiceConfiguration.class})
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class ExportTypeBasedConfigManagerTest {
 
   public static final String CONFIG_RESPONSE =

--- a/src/test/java/org/folio/des/validator/ExportConfigValidatorResolverTest.java
+++ b/src/test/java/org/folio/des/validator/ExportConfigValidatorResolverTest.java
@@ -15,12 +15,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.validation.Validator;
 
 @SpringBootTest(classes = {JacksonConfiguration.class, ServiceConfiguration.class})
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, QuartzAutoConfiguration.class})
 class ExportConfigValidatorResolverTest {
 
   @Autowired


### PR DESCRIPTION
## Purpose
[MODEXPS-185](https://issues.folio.org/browse/MODEXPS-185) Prepare initial setup for introducing Quartz as a scheduler in mod-data-export-spring

## Approach
Added initial quartz setup. It's disabled in application and enabled in the test for draft scheduler implementation (controlled by _folio.quartz.enabled_ property). When disabled, liquibase update is not done for quartz tables and scheduler is not started.

Implemented:
- use quartz with jdbc storage, clustered
- setup quartz tables using liquibase
- tables are created in the separate schema (defined by _folio.quartz.schemaName_) - there'll be a single set of quartz tables for all tenants
- created draft export scheduler implementation and added tests for it
- to enable quartz tables initialization and quartz scheduler start: set _folio.quartz.enabled=true_. For now it's disabled.

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Learning

-  [Using quartz in clustered environment](https://www.quartz-scheduler.org/documentation/quartz-2.3.0/configuration/ConfigJDBCJobStoreClustering.html)
-  [Job Stores](http://www.quartz-scheduler.org/documentation/quartz-2.2.2/tutorials/tutorial-lesson-09.html)
- [Quartz db setup](https://github.com/quartz-scheduler/quartz/wiki/How-to-Setup-Databases)
- [Liquibase quartz init](https://github.com/quartz-scheduler/quartz/blob/main/quartz-core/src/main/resources/org/quartz/impl/jdbcjobstore/liquibase.quartz.init.xml)

Here's how quartz schema with tables look:
![image](https://user-images.githubusercontent.com/11651407/230619321-02cec379-0ab6-428a-b904-dc1bee7ff7f2.png)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] Check logging
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
