### PR TITLE
MODEXPS-248: Spring Boot 3.1.8, Kafka 3.6.1, folio-spring-base 7.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,16 @@
       <artifactId>mockserver-client-java</artifactId>
       <version>${mockserver-client-java.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk18on</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/MODEXPS-248

Upgrade Spring Boot from 3.1.4 to 3.1.8.

The Spring Boot upgrade indirectly upgrades tomcat-embed-core from 10.1.13 to 10.1.18 fixing multiple vulnerabilities:

* Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2023-44487
* HTTP request smuggling: https://nvd.nist.gov/vuln/detail/CVE-2023-46589
* Access Restriction Bypass: https://nvd.nist.gov/vuln/detail/CVE-2023-41080
* HTTP request smuggling: https://nvd.nist.gov/vuln/detail/CVE-2023-45648
* Incomplete Cleanup: https://nvd.nist.gov/vuln/detail/CVE-2023-42795

The Spring Boot upgrade indirectly upgrades spring-boot-starter-actuator from 3.1.4 to 3.1.8 fixing Denial of Service (DoS):

* https://nvd.nist.gov/vuln/detail/CVE-2023-34055

Upgrade kafka from 3.4.1 to 3.6.1. The kafka-client upgrade upgrades snappy-java from 1.1.8.4 to 1.1.10.5 fixing these vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2023-43642 Allocation of Resources Without Limits or Throttling
* https://nvd.nist.gov/vuln/detail/CVE-2023-34455 Denial of Service (DoS)
* https://nvd.nist.gov/vuln/detail/CVE-2023-34453 Integer Overflow or Wraparound
* https://nvd.nist.gov/vuln/detail/CVE-2023-34454 Integer Overflow or Wraparound

Upgrade folio-spring-base from 7.2.0 to 7.2.2.

The folio-spring-base upgrade indirectly upgrades commons-fileupload from 1.4 to 1.5 fixing Denial of Service (DoS):

* https://nvd.nist.gov/vuln/detail/CVE-2023-24998

The folio-spring-base upgrade indirectly upgrade spring-web from 6.0.12 to 6.0.16 fixing Denial of Service (DoS):

* https://nvd.nist.gov/vuln/detail/CVE-2023-34053

Move mockserver-client-java from runtime dependency to test dependency. This removes com.jayway.jsonpath:json-path@2.8.0 dependency from the runtime. That json-path version has a Buffer Overflow vulnerability:

* https://nvd.nist.gov/vuln/detail/CVE-2023-51074

Exclude bouncycastle:bcprov-jdk18on and bouncycastle:bcpkix-jdk18on from mockserver-client-java dependency so that it no longer downgrades bcprov-jdk18on and bcpkix-jdk18on from 1.73 (provided by folio-spring-base) to 1.72. 1.72 is vulnerable: 

* https://nvd.nist.gov/vuln/detail/CVE-2023-33202