### PR TITLE
[MODEXPS-252] Add missing module permission for tenant install

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -236,6 +236,7 @@
             "perms.users.get",
             "configuration.entries.collection.get",
             "configuration.entries.item.post",
+            "configuration.entries.item.put",
             "perms.users.assign.immutable",
             "data-export.job.collection.get",
             "data-export.config.collection.get"


### PR DESCRIPTION
# [Jira MODEXPS-252](https://folio-org.atlassian.net/browse/MODEXPS-252)

## Purpose
The bursar migration logic added in #270/UXPROD-3903 requires an additional permission upon module install (to permit updating existing configurations).  This adds this permission to the ModuleDescriptor.