### PR TITLE
MODEXPS-263 - Remove usage of okapi-common lib, based on Vert.x classes, from Spring project

### DIFF
--- a/src/main/java/org/folio/des/util/ModuleId.java
+++ b/src/main/java/org/folio/des/util/ModuleId.java
@@ -2,6 +2,7 @@ package org.folio.des.util;
 
 import java.util.Collection;
 
+@Deprecated(forRemoval = true)
 public class ModuleId implements Comparable<ModuleId> {
 
   private final String product;

--- a/src/main/java/org/folio/des/util/SemVer.java
+++ b/src/main/java/org/folio/des/util/SemVer.java
@@ -11,6 +11,7 @@ import java.util.List;
  * is (eg 1) required or even more than 3 components for dot-separated
  * list (eg 1.2.3.4).
  */
+@Deprecated(forRemoval = true)
 public class SemVer implements Comparable<SemVer> {
 
   private final List<String> preRelease = new LinkedList<>();


### PR DESCRIPTION
[MODEXPS-263](https://folio-org.atlassian.net/browse/MODEXPS-263) - Remove usage of okapi-common lib, based on Vert.x classes, from Spring project

* Deprecate classes
