### PR TITLE
EUREKA-48 EDIFACT order export job does not run in scheduled time

### DIFF
--- a/src/main/java/org/folio/des/scheduling/quartz/job/OldDeleteJob.java
+++ b/src/main/java/org/folio/des/scheduling/quartz/job/OldDeleteJob.java
@@ -2,12 +2,13 @@ package org.folio.des.scheduling.quartz.job;
 
 import static org.folio.des.scheduling.quartz.QuartzConstants.TENANT_ID_PARAM;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.folio.des.service.JobService;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 @RequiredArgsConstructor
 @Log4j2

--- a/src/main/java/org/folio/des/scheduling/quartz/job/OldDeleteJob.java
+++ b/src/main/java/org/folio/des/scheduling/quartz/job/OldDeleteJob.java
@@ -2,32 +2,28 @@ package org.folio.des.scheduling.quartz.job;
 
 import static org.folio.des.scheduling.quartz.QuartzConstants.TENANT_ID_PARAM;
 
-import org.folio.des.service.JobService;
-import org.folio.spring.FolioExecutionContext;
-import org.folio.spring.context.ExecutionContextBuilder;
-import org.folio.spring.scope.FolioExecutionContextSetter;
-import org.folio.spring.service.SystemUserService;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.des.service.JobService;
+import org.folio.spring.service.SystemUserScopedExecutionService;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
 
 @RequiredArgsConstructor
 @Log4j2
 public class OldDeleteJob implements org.quartz.Job {
 
   private final JobService jobService;
-  private final ExecutionContextBuilder contextBuilder;
-  private final SystemUserService systemUserService;
+  private final SystemUserScopedExecutionService executionService;
   private static final String PARAM_NOT_FOUND_MESSAGE = "'%s' param is missing in the jobExecutionContext";
 
   @Override
   public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
     String tenantId = getTenantId(jobExecutionContext);
-    try (var context = new FolioExecutionContextSetter(folioExecutionContext(tenantId))) {
+    executionService.executeSystemUserScoped(tenantId, () -> {
       jobService.deleteOldJobs();
-    }
+      return null;
+    });
     log.info("execute:: deleteOldJobs executed");
   }
 
@@ -37,9 +33,5 @@ public class OldDeleteJob implements org.quartz.Job {
       throw new IllegalArgumentException(String.format(PARAM_NOT_FOUND_MESSAGE, TENANT_ID_PARAM));
     }
     return tenantId;
-  }
-
-  private FolioExecutionContext folioExecutionContext(String tenantId) {
-    return contextBuilder.forSystemUser(systemUserService.getAuthedSystemUser(tenantId));
   }
 }

--- a/src/main/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJob.java
+++ b/src/main/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJob.java
@@ -3,8 +3,6 @@ package org.folio.des.scheduling.quartz.job.acquisition;
 import static org.folio.des.scheduling.quartz.QuartzConstants.EXPORT_CONFIG_ID_PARAM;
 import static org.folio.des.scheduling.quartz.QuartzConstants.TENANT_ID_PARAM;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.folio.des.client.DataExportSpringClient;
 import org.folio.des.domain.dto.ExportConfig;
 import org.folio.des.domain.dto.Job;
@@ -15,6 +13,9 @@ import org.folio.spring.exception.NotFoundException;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @RequiredArgsConstructor

--- a/src/main/java/org/folio/des/scheduling/quartz/job/bursar/BursarJob.java
+++ b/src/main/java/org/folio/des/scheduling/quartz/job/bursar/BursarJob.java
@@ -4,8 +4,7 @@ import static org.folio.des.scheduling.quartz.QuartzConstants.EXPORT_CONFIG_ID_P
 import static org.folio.des.scheduling.quartz.QuartzConstants.TENANT_ID_PARAM;
 
 import java.util.Date;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+
 import org.folio.des.client.DataExportSpringClient;
 import org.folio.des.domain.dto.ExportConfig;
 import org.folio.des.domain.dto.Job;
@@ -16,6 +15,9 @@ import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobKey;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @RequiredArgsConstructor

--- a/src/main/java/org/folio/des/scheduling/quartz/job/bursar/BursarJob.java
+++ b/src/main/java/org/folio/des/scheduling/quartz/job/bursar/BursarJob.java
@@ -4,29 +4,23 @@ import static org.folio.des.scheduling.quartz.QuartzConstants.EXPORT_CONFIG_ID_P
 import static org.folio.des.scheduling.quartz.QuartzConstants.TENANT_ID_PARAM;
 
 import java.util.Date;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.folio.des.client.DataExportSpringClient;
 import org.folio.des.domain.dto.ExportConfig;
 import org.folio.des.domain.dto.Job;
 import org.folio.des.exceptions.SchedulingException;
 import org.folio.des.service.config.impl.ExportTypeBasedConfigManager;
-import org.folio.spring.FolioExecutionContext;
-import org.folio.spring.context.ExecutionContextBuilder;
 import org.folio.spring.exception.NotFoundException;
-import org.folio.spring.scope.FolioExecutionContextSetter;
-import org.folio.spring.service.SystemUserService;
+import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobKey;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-
 @Log4j2
 @RequiredArgsConstructor
 public class BursarJob implements org.quartz.Job {
-  private final ExecutionContextBuilder contextBuilder;
-  private final SystemUserService systemUserService;
+  private final SystemUserScopedExecutionService executionService;
   private final ExportTypeBasedConfigManager exportTypeBasedConfigManager;
   private final DataExportSpringClient dataExportSpringClient;
   private static final String PARAM_NOT_FOUND_MESSAGE = "'%s' param is missing in the jobExecutionContext";
@@ -37,11 +31,12 @@ public class BursarJob implements org.quartz.Job {
     String tenantId = getTenantId(jobExecutionContext);
     var current = new Date();
 
-    try (var context = new FolioExecutionContextSetter(folioExecutionContext(tenantId))) {
+    executionService.executeSystemUserScoped(tenantId, () -> {
       Job scheduledJob = getJob(jobExecutionContext);
       Job resultJob = dataExportSpringClient.upsertJob(scheduledJob);
       log.info("execute:: configureTasks executed for jobId: {} at: {}", resultJob.getId(), current);
-    }
+      return null;
+    });
   }
 
   private Job getJob(JobExecutionContext jobExecutionContext) {
@@ -89,9 +84,5 @@ public class BursarJob implements org.quartz.Job {
     } catch (Exception e) {
       log.warn("deleteJob:: exception deleting job '{}'", jobKey, e);
     }
-  }
-
-  private FolioExecutionContext folioExecutionContext(String tenantId) {
-    return contextBuilder.forSystemUser(systemUserService.getAuthedSystemUser(tenantId));
   }
 }

--- a/src/test/java/org/folio/des/scheduling/quartz/job/OldDeleteJobTest.java
+++ b/src/test/java/org/folio/des/scheduling/quartz/job/OldDeleteJobTest.java
@@ -12,10 +12,11 @@ import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.context.ExecutionContextBuilder;
 import org.folio.spring.model.SystemUser;
+import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.service.SystemUserService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobDetail;
@@ -36,11 +37,18 @@ class OldDeleteJobTest {
   private ExecutionContextBuilder contextBuilder;
   @Mock
   private SystemUserService systemUserService;
-  @InjectMocks
-  private OldDeleteJob oldDeleteJob;
   @Mock
   private JobExecutionContext jobExecutionContext;
   private final FolioExecutionContext folioExecutionContext = new TestFolioExecutionContext();
+
+  private OldDeleteJob oldDeleteJob;
+
+  @BeforeEach
+  void setUp() {
+    var executionService = new SystemUserScopedExecutionService(folioExecutionContext, contextBuilder);
+    executionService.setSystemUserService(systemUserService);
+    oldDeleteJob = new OldDeleteJob(jobService, executionService);
+  }
 
   @Test
   void testSuccessfulExecute() throws JobExecutionException {

--- a/src/test/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJobTest.java
+++ b/src/test/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJobTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
-
 import org.folio.des.builder.job.JobCommandSchedulerBuilder;
 import org.folio.des.client.DataExportSpringClient;
 import org.folio.des.domain.dto.EdiSchedule;
@@ -30,10 +29,11 @@ import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.context.ExecutionContextBuilder;
 import org.folio.spring.exception.NotFoundException;
 import org.folio.spring.model.SystemUser;
+import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.service.SystemUserService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobDetail;
@@ -57,8 +57,6 @@ class EdifactJobTest {
   private SystemUserService systemUserService;
   @Mock
   private ExportTypeBasedConfigManager exportTypeBasedConfigManager;
-  @InjectMocks
-  private EdifactJob edifactJob;
   @Mock
   private JobExecutionContext jobExecutionContext;
   @Mock
@@ -66,10 +64,20 @@ class EdifactJobTest {
   @Mock
   private DataExportSpringClient dataExportSpringClient;
   private FolioExecutionContext folioExecutionContext = new TestFolioExecutionContext();
+
+  private EdifactJob edifactJob;
+
   private static final String TENANT_ID = "some_test_tenant";
   private static final String EXPORT_CONFIG_ID = "some_test_export_config_id";
   private static final ExportType EXPORT_TYPE = ExportType.EDIFACT_ORDERS_EXPORT;
   private static final JobKey JOB_KEY = JobKey.jobKey("testJobKey", "testJobGroup");
+
+  @BeforeEach
+  void setUp() {
+    var executionService = new SystemUserScopedExecutionService(folioExecutionContext, contextBuilder);
+    executionService.setSystemUserService(systemUserService);
+    edifactJob = new EdifactJob(exportTypeBasedConfigManager, jobService, executionService, dataExportSpringClient);
+  }
 
   @Test
   void testExecuteSuccessful() {

--- a/src/test/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJobTest.java
+++ b/src/test/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJobTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
+
 import org.folio.des.builder.job.JobCommandSchedulerBuilder;
 import org.folio.des.client.DataExportSpringClient;
 import org.folio.des.domain.dto.EdiSchedule;

--- a/src/test/java/org/folio/des/scheduling/quartz/job/bursar/BursarJobTest.java
+++ b/src/test/java/org/folio/des/scheduling/quartz/job/bursar/BursarJobTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
+
 import org.folio.des.builder.job.JobCommandSchedulerBuilder;
 import org.folio.des.client.DataExportSpringClient;
 import org.folio.des.domain.dto.EdiSchedule;

--- a/src/test/java/org/folio/des/scheduling/quartz/job/bursar/BursarJobTest.java
+++ b/src/test/java/org/folio/des/scheduling/quartz/job/bursar/BursarJobTest.java
@@ -3,13 +3,10 @@ package org.folio.des.scheduling.quartz.job.bursar;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
-
 import org.folio.des.builder.job.JobCommandSchedulerBuilder;
 import org.folio.des.client.DataExportSpringClient;
 import org.folio.des.domain.dto.EdiSchedule;
@@ -28,10 +25,11 @@ import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.context.ExecutionContextBuilder;
 import org.folio.spring.exception.NotFoundException;
 import org.folio.spring.model.SystemUser;
+import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.service.SystemUserService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobDetail;
@@ -62,8 +60,6 @@ class BursarJobTest {
   private SystemUserService systemUserService;
   @Mock
   private ExportTypeBasedConfigManager exportTypeBasedConfigManager;
-  @InjectMocks
-  private BursarJob bursarJob;
   @Mock
   private JobExecutionContext jobExecutionContext;
   @Mock
@@ -71,6 +67,15 @@ class BursarJobTest {
   @Mock
   private DataExportSpringClient dataExportSpringClient;
   private final FolioExecutionContext folioExecutionContext = new TestFolioExecutionContext();
+
+  private BursarJob bursarJob;
+
+  @BeforeEach
+  void setUp() {
+    var executionService = new SystemUserScopedExecutionService(folioExecutionContext, contextBuilder);
+    executionService.setSystemUserService(systemUserService);
+    bursarJob = new BursarJob(executionService, exportTypeBasedConfigManager, dataExportSpringClient);
+  }
 
   @Test
   void testSuccessfulExecute() throws JobExecutionException {


### PR DESCRIPTION
## Purpose
In case of disabled system user functionality jobs are not executed because they require `SystemUserService` which is not available in this mode. Solution to this issue is using `SystemUserScopedExecutionService`
US: [EUREKA-48](https://folio-org.atlassian.net/browse/EUREKA-48)

## Approach
* use SystemUserScopedExecutionService to hide details of making calls on behalf of system user

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
