### PR TITLE
EUREKA-48 Call job execution service directly instead of calling it via API when System user functionality disabled

### DIFF
--- a/src/main/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJob.java
+++ b/src/main/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJob.java
@@ -41,6 +41,9 @@ public class EdifactJob implements org.quartz.Job {
         Job resultJob = jobService.upsertAndSendToKafka(job, false, false);
         log.info("execute:: configured task saved in DB jobId: {}", resultJob.getId());
         if (resultJob.getId() != null) {
+          // To support RTR the job is calling job execution service via module's API /jobs/send.
+          // This doesn't work for Eureka. Solution is to call the service directly in case of system user functionality
+          // is disabled (Eureka mode) and call the API in another case
           if (systemUserProperties.isEnabled()) {
             dataExportSpringClient.sendJob(resultJob);
           } else {

--- a/src/main/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJob.java
+++ b/src/main/java/org/folio/des/scheduling/quartz/job/acquisition/EdifactJob.java
@@ -3,13 +3,16 @@ package org.folio.des.scheduling.quartz.job.acquisition;
 import static org.folio.des.scheduling.quartz.QuartzConstants.EXPORT_CONFIG_ID_PARAM;
 import static org.folio.des.scheduling.quartz.QuartzConstants.TENANT_ID_PARAM;
 
+import org.folio.des.builder.job.JobCommandSchedulerBuilder;
 import org.folio.des.client.DataExportSpringClient;
 import org.folio.des.domain.dto.ExportConfig;
 import org.folio.des.domain.dto.Job;
 import org.folio.des.exceptions.SchedulingException;
+import org.folio.des.service.JobExecutionService;
 import org.folio.des.service.JobService;
 import org.folio.des.service.config.impl.ExportTypeBasedConfigManager;
 import org.folio.spring.exception.NotFoundException;
+import org.folio.spring.service.SystemUserProperties;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobKey;
@@ -23,7 +26,10 @@ public class EdifactJob implements org.quartz.Job {
   private static final String PARAM_NOT_FOUND_MESSAGE = "'%s' param is missing in the jobExecutionContext";
   private final ExportTypeBasedConfigManager exportTypeBasedConfigManager;
   private final JobService jobService;
+  private final JobCommandSchedulerBuilder jobCommandSchedulerBuilder;
+  private final JobExecutionService jobExecutionService;
   private final SystemUserScopedExecutionService executionService;
+  private final SystemUserProperties systemUserProperties;
   private final DataExportSpringClient dataExportSpringClient;
 
   @Override
@@ -35,7 +41,11 @@ public class EdifactJob implements org.quartz.Job {
         Job resultJob = jobService.upsertAndSendToKafka(job, false, false);
         log.info("execute:: configured task saved in DB jobId: {}", resultJob.getId());
         if (resultJob.getId() != null) {
-          dataExportSpringClient.sendJob(resultJob);
+          if (systemUserProperties.isEnabled()) {
+            dataExportSpringClient.sendJob(resultJob);
+          } else {
+            jobExecutionService.sendJobCommand(jobCommandSchedulerBuilder.buildJobCommand(resultJob));
+          }
           log.info("execute:: configured task scheduled and sent to kafka for jobId: {}", resultJob.getId());
         }
         return null;


### PR DESCRIPTION
## Purpose
To support RTR Edifact job is calling job execution service via module's API `/jobs/send`. This doesn't work for Eureka. Solution is to call the service directly in case of system user functionality is disabled and call the API in another case
US: [EUREKA-48](https://folio-org.atlassian.net/browse/EUREKA-48)

## Approach
* conditionally call service or API depending on System User enabled or not

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
