### PR TITLE
MODEXPS-270: Fix org.bouncycastle:bcprov-jdk18on:1.72 vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.10</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -33,7 +33,7 @@
     <export-configs.yaml.file>${project.basedir}/src/main/resources/swagger.api/export-configs.yaml
     </export-configs.yaml.file>
 
-    <folio-spring-base.version>8.1.0</folio-spring-base.version>
+    <folio-spring-base.version>8.1.2</folio-spring-base.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <hypersistence-utils-hibernate-63.version>3.7.3</hypersistence-utils-hibernate-63.version>
     <commons-collections4.version>4.4</commons-collections4.version>
@@ -244,16 +244,12 @@
       <artifactId>mockserver-client-java</artifactId>
       <version>${mockserver-client-java.version}</version>
       <scope>test</scope>
-      <!--exclusions>
+      <exclusions>
         <exclusion>
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcprov-jdk18on</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcpkix-jdk18on</artifactId>
-        </exclusion>
-      </exclusions-->
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODEXPS-270

## Purpose
Fix org.bouncycastle:bcprov-jdk18on:1.72 vulnerabilities
See https://security.snyk.io/package/maven/org.bouncycastle:bcprov-jdk18on/1.72

## Approach
Upgrade spring-boot-starter-parent from 3.2.3 to 3.2.10.
Ensure that mockserver-client-java doesn't downgrade org.bouncycastle:bcprov-jdk18on.

## Learning
mod-data-export-spring should have updated all dependencies before releasing the Quesnelia version 3.3.0.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.