### PR TITLE
[MODEXPS-273]. Add support for multi-value querying of configs using other predicates

### DIFF
--- a/src/main/java/org/folio/des/controller/ConfigsController.java
+++ b/src/main/java/org/folio/des/controller/ConfigsController.java
@@ -17,18 +17,19 @@ import java.util.EnumSet;
 
 import static org.folio.des.domain.dto.ExportType.EDIFACT_ORDERS_EXPORT;
 
-@RestController
-@RequestMapping("/data-export-spring")
-@RequiredArgsConstructor
 @Log4j2
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/data-export-spring")
 public class ConfigsController implements ConfigsApi {
+
   private final EnumSet<ExportType> applyAspectExportTypes = EnumSet.of(EDIFACT_ORDERS_EXPORT);
   private final ExportTypeBasedConfigManager manager;
 
   @Override
   public ResponseEntity<ExportConfigCollection> getExportConfigs(String query, Integer limit) {
-      log.info("getExportConfigs:: by query={} with limit={}", query, limit);
-      return ResponseEntity.ok(manager.getConfigCollection(query, limit));
+    log.info("getExportConfigs:: by query={} with limit={}", query, limit);
+    return ResponseEntity.ok(manager.getConfigCollection(query, limit));
   }
 
   @Override

--- a/src/main/java/org/folio/des/domain/FilterOperator.java
+++ b/src/main/java/org/folio/des/domain/FilterOperator.java
@@ -1,0 +1,13 @@
+package org.folio.des.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FilterOperator {
+  OR_OPERATOR(" OR "),
+  AND_OPERATOR(" AND ");
+
+  private final String value;
+}

--- a/src/main/java/org/folio/des/domain/FilterPredicate.java
+++ b/src/main/java/org/folio/des/domain/FilterPredicate.java
@@ -1,0 +1,13 @@
+package org.folio.des.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FilterPredicate {
+  BY_TYPE_CONDITION("type=="),
+  BY_VALUE_CONDITION("value==");
+
+  private final String value;
+}

--- a/src/main/java/org/folio/des/service/config/impl/BaseExportConfigService.java
+++ b/src/main/java/org/folio/des/service/config/impl/BaseExportConfigService.java
@@ -20,9 +20,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 
-@RequiredArgsConstructor
 @Log4j2
+@RequiredArgsConstructor
 public class BaseExportConfigService implements ExportConfigService {
+
   protected final ConfigurationClient client;
   protected final DefaultModelConfigToExportConfigConverter defaultModelConfigToExportConfigConverter;
   protected final ExportConfigConverterResolver exportConfigConverterResolver;

--- a/src/main/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManager.java
+++ b/src/main/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManager.java
@@ -102,7 +102,7 @@ public class ExportTypeBasedConfigManager {
       return List.of();
     }
     var exportTypes = new ArrayList<ExportType>();
-    query = query.replaceAll("type==", "").toUpperCase();
+    query = query.replace("type==", "").toUpperCase();
     for (var entry : query.split(" OR ")) {
       var matcher = exportTypePattern.matcher(entry);
       if (!matcher.find()) {
@@ -129,7 +129,7 @@ public class ExportTypeBasedConfigManager {
       query = DEFAULT_MODULE_QUERY + " AND " + query;
     }
     if (CollectionUtils.isNotEmpty(exportTypes)) {
-      query = query.replaceAll("type==", "value==(");
+      query = query.replace("type==", "value==(");
       for (ExportType exportType : exportTypes) {
         query = query.replaceAll(exportType.name(), String.format("*%s*", exportType));
       }

--- a/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
+++ b/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
@@ -11,7 +11,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.ResultMatcher.matchAll;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -39,6 +38,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 
+import java.util.Objects;
+
 class ConfigsControllerTest extends BaseTest {
 
   private static final String NEW_CONFIG_REQUEST =
@@ -49,7 +50,8 @@ class ConfigsControllerTest extends BaseTest {
     "{\"id\":\"0a3cba78-16e7-498e-b75b-98713000277b\",\"type\":\"BURSAR_FEES_FINES\",\"scheduleFrequency\":5,\"schedulePeriod\":\"DAY\",\"scheduleTime\":\"00:20:00.000Z\"}";
   private static final String EDIFACT_CONFIG_REQUEST =
     "{\"id\":\"5a3cba28-16e7-498e-b73b-98713000298e\", \"type\": \"EDIFACT_ORDERS_EXPORT\", \"exportTypeSpecificParameters\": { \"vendorEdiOrdersExportConfig\": {\"vendorId\": \"046b6c7f-0b8a-43b9-b35d-6489e6daee91\", \"configName\": \"edi_config\", \"ediSchedule\": {\"enableScheduledExport\": true, \"scheduleParameters\": {\"scheduleFrequency\": 1, \"schedulePeriod\": \"HOUR\", \"scheduleTime\": \"15:30:00\"}}}}, \"schedulePeriod\": \"HOUR\"}";
-
+  private static final String CLAIMS_REQUEST =
+    "{\"id\":\"30ad9c6d-f2e7-425f-a171-b4e0cbce7204\",\"type\":\"CLAIMS\",\"tenant\":\"diku\",\"exportTypeSpecificParameters\":{\"vendorEdiOrdersExportConfig\":{\"exportConfigId\":\"30ad9c6d-f2e7-425f-a171-b4e0cbce7204\",\"vendorId\":\"1e958895-82a6-4fa1-b6fe-763063381946\",\"configName\":\"Test 1-3\",\"ediConfig\":{\"accountNoList\":[\"3\"],\"ediNamingConvention\":\"{organizationCode}-{integrationName}-{exportJobEndDate}\",\"libEdiType\":\"31B/US-SAN\",\"vendorEdiType\":\"31B/US-SAN\",\"sendAccountNumber\":false,\"supportOrder\":false,\"supportInvoice\":false},\"ediFtp\":{\"ftpConnMode\":\"Active\",\"ftpFormat\":\"SFTP\",\"ftpMode\":\"ASCII\"},\"isDefaultConfig\":false,\"integrationType\":\"Claiming\",\"transmissionMethod\":\"File download\",\"fileFormat\":\"CSV\"}},\"schedulePeriod\":\"NONE\"}";
 
   @Autowired private MockMvc mockMvc;
 
@@ -63,12 +65,18 @@ class ConfigsControllerTest extends BaseTest {
 
   @ParameterizedTest
   @CsvSource({
-    "/data-export-spring/configs, module==mod-data-export-spring",
-    "/data-export-spring/configs?query=type==BURSAR_FEES_FINES, module==mod-data-export-spring and configName==export_config_parameters",
-    "/data-export-spring/configs?query=type==BATCH_VOUCHER_EXPORT, module==mod-data-export-spring and value==*BATCH_VOUCHER_EXPORT*"
+    "/data-export-spring/configs, module==mod-data-export-spring,",
+    "/data-export-spring/configs?query=type==BURSAR_FEES_FINES, module==mod-data-export-spring and configName==export_config_parameters,",
+    "/data-export-spring/configs?query=type==BATCH_VOUCHER_EXPORT, module==mod-data-export-spring AND value==*BATCH_VOUCHER_EXPORT*,",
+    "/data-export-spring/configs?query=type==EDIFACT_ORDERS_EXPORT, module==mod-data-export-spring AND value==*EDIFACT_ORDERS_EXPORT*,",
+    "/data-export-spring/configs?query=type==(EDIFACT_ORDERS_EXPORT), module==mod-data-export-spring AND value==*EDIFACT_ORDERS_EXPORT*,",
+    "/data-export-spring/configs?query=type==CLAIMS, module==mod-data-export-spring AND value==*CLAIMS*,",
+    "/data-export-spring/configs?query=type==(CLAIMS), module==mod-data-export-spring AND value==*CLAIMS*,",
+    "/data-export-spring/configs?query=type==(CLAIMS OR EDIFACT_ORDERS_EXPORT), module==mod-data-export-spring AND value==*CLAIMS*, module==mod-data-export-spring AND value==*EDIFACT_ORDERS_EXPORT*",
+    "/data-export-spring/configs?query=type==(CLAIMS OR BATCH_VOUCHER_EXPORT), module==mod-data-export-spring AND value==*CLAIMS*, module==mod-data-export-spring AND value==*BATCH_VOUCHER_EXPORT*",
   })
   @DisplayName("Fetch config by query")
-  void getConfigs(String exportConfigQuery, String modConfigQuery) throws Exception {
+  void getConfigs(String exportConfigQuery, String firstModConfigQuery, String secondModConfigQuery) throws Exception {
     var config = new ConfigurationCollection();
     config.setTotalRecords(0);
     wireMockServer.stubFor(WireMock.get(anyUrl())
@@ -81,13 +89,14 @@ class ConfigsControllerTest extends BaseTest {
         get(exportConfigQuery)
           .contentType(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders()))
-      .andExpect(
-        matchAll(
-          status().isOk(),
+      .andExpectAll(status().isOk(),
           content().contentType(MediaType.APPLICATION_JSON_VALUE),
-          jsonPath("$.totalRecords", is(0))));
+          jsonPath("$.totalRecords", is(0)));
 
-    verify(configurationClient, times(1)).getConfigurations(eq(modConfigQuery), any());
+    verify(configurationClient, times(1)).getConfigurations(eq(firstModConfigQuery), any());
+    if (Objects.nonNull(secondModConfigQuery)) {
+      verify(configurationClient, times(1)).getConfigurations(eq(secondModConfigQuery), any());
+    }
   }
 
   @Test
@@ -99,10 +108,8 @@ class ConfigsControllerTest extends BaseTest {
           .contentType(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders())
           .content(NEW_CONFIG_REQUEST))
-      .andExpect(
-        matchAll(
-          status().isCreated(),
-          content().contentType("text/plain;charset=UTF-8")));
+      .andExpectAll(status().isCreated(),
+          content().contentType("text/plain;charset=UTF-8"));
 
     verify(bursarExportScheduler).scheduleBursarJob(any(ExportConfig.class));
   }
@@ -116,11 +123,21 @@ class ConfigsControllerTest extends BaseTest {
           .contentType(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders())
           .content(EDIFACT_CONFIG_REQUEST))
-      .andExpect(
-        matchAll(
-          status().isCreated(),
-          content().contentType("text/plain;charset=UTF-8")));
+      .andExpectAll(status().isCreated(),
+          content().contentType("text/plain;charset=UTF-8"));
+  }
 
+  @Test
+  @DisplayName("Success posted claims config")
+  void postClaimsConfig() throws Exception {
+    mockMvc
+      .perform(
+        post("/data-export-spring/configs")
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .headers(defaultHeaders())
+          .content(CLAIMS_REQUEST))
+      .andExpectAll(status().isCreated(),
+          content().contentType("text/plain;charset=UTF-8"));
   }
 
   @Test
@@ -137,7 +154,7 @@ class ConfigsControllerTest extends BaseTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .headers(defaultHeaders())
                 .content(UPDATE_CONFIG_REQUEST))
-        .andExpect(matchAll(status().isNoContent()));
+        .andExpectAll(status().isNoContent());
 
     verify(bursarExportScheduler).scheduleBursarJob(any(ExportConfig.class));
   }
@@ -156,9 +173,7 @@ class ConfigsControllerTest extends BaseTest {
           .contentType(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders())
           .content(UPDATE_CONFIG_REQUEST))
-      .andExpect(
-        matchAll(
-          status().isBadRequest()));
+      .andExpectAll(status().isBadRequest());
 
   }
 
@@ -166,15 +181,14 @@ class ConfigsControllerTest extends BaseTest {
   @DisplayName("Fail update config")
   void putConfigFail() throws Exception {
     mockMvc
-        .perform(
-            put("/data-export-spring/configs/c8303ff3-7dec-49a1-acc8-7ce4f311fe21")
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .headers(defaultHeaders())
-                .content(UPDATE_CONFIG_REQUEST_FAILED))
-        .andExpect(
-          matchAll(status().isBadRequest(),
-            content().contentType(MediaType.APPLICATION_JSON_VALUE),
-            jsonPath("$.errors[0].type", is("MethodArgumentNotValidException"))));
+      .perform(
+          put("/data-export-spring/configs/c8303ff3-7dec-49a1-acc8-7ce4f311fe21")
+              .contentType(MediaType.APPLICATION_JSON_VALUE)
+              .headers(defaultHeaders())
+              .content(UPDATE_CONFIG_REQUEST_FAILED))
+      .andExpectAll(status().isBadRequest(),
+         content().contentType(MediaType.APPLICATION_JSON_VALUE),
+         jsonPath("$.errors[0].type", is("MethodArgumentNotValidException")));
   }
 
   @Test
@@ -196,10 +210,9 @@ class ConfigsControllerTest extends BaseTest {
         get("/data-export-spring/configs/c8303ff3-7dec-49a1-acc8-7ce4f311fe21")
           .accept(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders()))
-      .andExpect(matchAll(
-        status().isOk(),
-        content().contentType(MediaType.APPLICATION_JSON_VALUE),
-        jsonPath("$.id", is("c8303ff3-7dec-49a1-acc8-7ce4f311fe21"))));
+      .andExpectAll(status().isOk(),
+         content().contentType(MediaType.APPLICATION_JSON_VALUE),
+         jsonPath("$.id", is("c8303ff3-7dec-49a1-acc8-7ce4f311fe21")));
 
   }
 
@@ -217,10 +230,9 @@ class ConfigsControllerTest extends BaseTest {
         get("/data-export-spring/configs/c8303ff3-7dec-49a1-acc8-7ce4f311fe21")
           .accept(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders()))
-      .andExpect(matchAll(
-        status().isNotFound(),
-        content().contentType(MediaType.APPLICATION_JSON_VALUE),
-        jsonPath("$.errors[0].type", is("NotFoundException"))));
+      .andExpectAll(status().isNotFound(),
+         content().contentType(MediaType.APPLICATION_JSON_VALUE),
+         jsonPath("$.errors[0].type", is("NotFoundException")));
   }
 
   @Test
@@ -236,10 +248,9 @@ class ConfigsControllerTest extends BaseTest {
         get("/data-export-spring/configs/c8303ff3-7dec-49a1-acc8-7ce4f311fe21")
           .accept(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders()))
-      .andExpect(matchAll(
-        status().isNotFound(),
-        content().contentType(MediaType.APPLICATION_JSON_VALUE),
-        jsonPath("$.errors[0].type", is("NotFoundException"))));
+      .andExpectAll(status().isNotFound(),
+         content().contentType(MediaType.APPLICATION_JSON_VALUE),
+         jsonPath("$.errors[0].type", is("NotFoundException")));
   }
 
   @Test
@@ -254,7 +265,7 @@ class ConfigsControllerTest extends BaseTest {
         delete("/data-export-spring/configs/c8303ff3-7dec-49a1-acc8-7ce4f311fe21")
           .accept(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders()))
-      .andExpect(matchAll(status().isNoContent()));
+      .andExpectAll(status().isNoContent());
   }
 
   @Test
@@ -270,9 +281,8 @@ class ConfigsControllerTest extends BaseTest {
         delete("/data-export-spring/configs/c8303ff3-7dec-49a1-acc8-7ce4f311fe21")
           .accept(MediaType.APPLICATION_JSON_VALUE)
           .headers(defaultHeaders()))
-      .andExpect(matchAll(
-        status().isNotFound(),
-        content().contentType(MediaType.APPLICATION_JSON_VALUE),
-        jsonPath("$.errors[0].type", is("NotFoundException"))));
+      .andExpectAll(status().isNotFound(),
+         content().contentType(MediaType.APPLICATION_JSON_VALUE),
+         jsonPath("$.errors[0].type", is("NotFoundException")));
   }
 }

--- a/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
+++ b/src/test/java/org/folio/des/controller/ConfigsControllerTest.java
@@ -74,6 +74,9 @@ class ConfigsControllerTest extends BaseTest {
     "/data-export-spring/configs?query=type==(CLAIMS), module==mod-data-export-spring AND value==*CLAIMS*,",
     "/data-export-spring/configs?query=type==(CLAIMS OR EDIFACT_ORDERS_EXPORT), module==mod-data-export-spring AND value==*CLAIMS*, module==mod-data-export-spring AND value==*EDIFACT_ORDERS_EXPORT*",
     "/data-export-spring/configs?query=type==(CLAIMS OR BATCH_VOUCHER_EXPORT), module==mod-data-export-spring AND value==*CLAIMS*, module==mod-data-export-spring AND value==*BATCH_VOUCHER_EXPORT*",
+    "/data-export-spring/configs?query=configName==\"EDIFACT_ORDERS_EXPORT_079e28a8-bf6d-4424-8461-13a3b1c3ec71**\", module==mod-data-export-spring AND configName==\"EDIFACT_ORDERS_EXPORT_079e28a8-bf6d-4424-8461-13a3b1c3ec71**\",",
+    "/data-export-spring/configs?query=configName==\"CLAIMS_1e958895-82a6-4fa1-b6fe-763063381946*\", module==mod-data-export-spring AND configName==\"CLAIMS_1e958895-82a6-4fa1-b6fe-763063381946*\",",
+    "/data-export-spring/configs?query=configName==(\"CLAIMS_2e6623c8-e201-48e8-bfae-e6426f04bea3*\" OR \"EDIFACT_ORDERS_EXPORT_079e28a8-bf6d-4424-8461-13a3b1c3ec71*\"), module==mod-data-export-spring AND configName==(\"CLAIMS_2e6623c8-e201-48e8-bfae-e6426f04bea3*\" OR \"EDIFACT_ORDERS_EXPORT_079e28a8-bf6d-4424-8461-13a3b1c3ec71*\"),",
   })
   @DisplayName("Fetch config by query")
   void getConfigs(String exportConfigQuery, String firstModConfigQuery, String secondModConfigQuery) throws Exception {


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODEXPS-273>

## Approach

- Add support for multi-value querying of configs using other default predicates, such as by `configName`
> e.g. `/data-export-spring/configs?query=configName==("CLAIMS_2e6623c8-e201-48e8-bfae-e6426f04bea3*" or "EDIFACT_ORDERS_EXPORT_079e28a8-bf6d-4424-8461-13a3b1c3ec71*")`
- Update integration tests
