### PR TITLE
[MODEXPS-282]. Existing export methods are not displayed in the dropdown on "Search & filter" pane in "Export manager"

### DIFF
--- a/src/main/java/org/folio/des/domain/FilterOperator.java
+++ b/src/main/java/org/folio/des/domain/FilterOperator.java
@@ -6,8 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum FilterOperator {
-  OR_OPERATOR(" OR "),
-  AND_OPERATOR(" AND ");
+  OR_OPERATOR(" OR ", "(?i)( OR )"),
+  AND_OPERATOR(" AND ", "(?i)( AND )");
 
   private final String value;
+  private final String regexPattern;
 }

--- a/src/main/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManager.java
+++ b/src/main/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManager.java
@@ -9,6 +9,7 @@ import static org.folio.des.service.config.ExportConfigConstants.DEFAULT_MODULE_
 
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -113,7 +114,7 @@ public class ExportTypeBasedConfigManager {
     if (StringUtils.isEmpty(query)) {
       return List.of();
     }
-    var exportTypes = new ArrayList<ExportType>();
+    var exportTypes = new HashSet<ExportType>();
     for (var entry : query.split(OR_OPERATOR.getRegexPattern())) {
       var matcher = exportTypePattern.matcher(entry);
       if (!matcher.find()) {
@@ -124,7 +125,7 @@ public class ExportTypeBasedConfigManager {
         exportTypes.add(ExportType.valueOf(exportTypeString));
       }
     }
-    return exportTypes.stream().distinct().toList();
+    return new ArrayList<>(exportTypes);
   }
 
   private String normalizeQuery(ExportType exportType) {

--- a/src/main/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManager.java
+++ b/src/main/java/org/folio/des/service/config/impl/ExportTypeBasedConfigManager.java
@@ -114,7 +114,7 @@ public class ExportTypeBasedConfigManager {
       return List.of();
     }
     var exportTypes = new ArrayList<ExportType>();
-    for (var entry : query.split(OR_OPERATOR.getValue())) {
+    for (var entry : query.split(OR_OPERATOR.getRegexPattern())) {
       var matcher = exportTypePattern.matcher(entry);
       if (!matcher.find()) {
         continue;
@@ -124,7 +124,7 @@ public class ExportTypeBasedConfigManager {
         exportTypes.add(ExportType.valueOf(exportTypeString));
       }
     }
-    return exportTypes;
+    return exportTypes.stream().distinct().toList();
   }
 
   private String normalizeQuery(ExportType exportType) {


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODEXPS-282>
 
## Approach

- Change string splitting to use a case-insensitive regexp pattern
- Add export type duplication protection
- Update integration tests
- Manually tested on Thunderjet edev cluster with Telepresence