### PR TITLE
MODEXPS-287 - Fix export failing on long outputFormat when translated

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -13,5 +13,6 @@
   <include file="changes/db.changelog-3.5.0.xml" relativeToChangelogFile="true"/>
   <include file="changes/03-03-2025_delete_enum_types.xml" relativeToChangelogFile="true"/>
   <include file="changes/03_10_2025_populate_orders_jobs_missing_fields.xml" relativeToChangelogFile="true"/>
+  <include file="changes/05_16_2025_alter_job_output_format.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/05_16_2025_alter_job_output_format.xml
+++ b/src/main/resources/db/changelog/changes/05_16_2025_alter_job_output_format.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="05_16_2025_alter_job_output_format" author="viacheslav_kolesnyk">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="job"/>
+                <sqlCheck expectedResult="character varying">
+                    SELECT data_type
+                    FROM information_schema.columns
+                    WHERE table_schema = '${database.defaultSchemaName}'
+                    AND table_name = 'job'
+                    AND column_name = 'output_format';
+                </sqlCheck>
+            </and>
+        </preConditions>
+
+        <sql>
+            ALTER TABLE job ALTER COLUMN output_format TYPE text;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
Fix export failing on long outputFormat when translated
[MODEXPS-287](https://folio-org.atlassian.net/browse/MODEXPS-287)

## Approach
- Change outputFormat column type from varchar(50) to text