### PR TITLE
FOLIO-4553: Set "permissions: contents: read" in maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,9 +1,14 @@
+# https://github.com/folio-org/.github/blob/master/README-maven.md
+
 name: Maven central workflow
 
 on:
   push:
   pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   maven:


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4553

## Purpose

Adding `permissions: contents: read` to the repository’s maven.yml file that calls the central maven github action workflow is best practice and significantly reduces supply chain attacks: https://docs.github.com/en/actions/reference/security/secure-use

Suggested maven.yml: https://github.com/folio-org/.github/blob/master/README-maven.md#usage

## Approach

Add `permissions: contents: read` to maven.yml

## Learning
Follow documentation: https://github.com/folio-org/.github/blob/master/README-maven.md#usage

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - n/a Code coverage on new code is 80% or greater
  - n/a Duplications on new code is 3% or less
  - n/a Check logging
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - n/a Were any API paths or methods changed, added or removed?
  - n/a Were there any schema changes?
  - n/a Did any of the interface versions change?
  - n/a Were permissions changed, added, or removed?
  - n/a Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.