### PR TITLE
MODEXPW-638 - Add custom-fields read permission for the order email export

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "folio-export-common"]
 	path = folio-export-common
 	url = https://github.com/folio-org/folio-export-common.git
+	branch = MODEXPW-638

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -98,6 +98,7 @@
             "orders-storage.purchase-orders.collection.get",
             "orders-storage.pieces.collection.get",
             "orders-storage.titles.item.get",
+            "orders-storage.custom-fields.collection.get",
             "transfers.collection.get",
             "users.collection.get",
             "users.item.get",
@@ -207,6 +208,7 @@
             "orders-storage.purchase-orders.collection.get",
             "orders-storage.pieces.collection.get",
             "orders-storage.titles.item.get",
+            "orders-storage.custom-fields.collection.get",
             "transfers.collection.get",
             "users.collection.get",
             "users.item.get",
@@ -409,7 +411,8 @@
         "organizations-storage.organizations.item.get",
         "orders-storage.po-lines.collection.get",
         "orders-storage.purchase-orders.collection.get",
-        "orders-storage.pieces.collection.get"
+        "orders-storage.pieces.collection.get",
+        "orders-storage.custom-fields.collection.get"
       ]
     },
     {
@@ -475,6 +478,7 @@
         "orders-storage.purchase-orders.collection.get",
         "orders-storage.pieces.collection.get",
         "orders-storage.titles.item.get",
+        "orders-storage.custom-fields.collection.get",
         "transfers.collection.get",
         "users.collection.get",
         "users.item.get",

--- a/src/main/resources/permissions/system-user-permissions.csv
+++ b/src/main/resources/permissions/system-user-permissions.csv
@@ -19,6 +19,7 @@ orders-storage.po-lines.collection.get
 orders-storage.purchase-orders.collection.get
 orders-storage.pieces.collection.get
 orders-storage.titles.item.get
+orders-storage.custom-fields.collection.get
 transfers.collection.get
 users.collection.get
 users.item.get


### PR DESCRIPTION
[MODEXPW-638](https://folio-org.atlassian.net/browse/MODEXPW-638) - Add custom-fields read permission for the order email export

## Purpose

The EDIFACT/CSV order email export renders PO and PO-line custom fields as template tokens (`order.customFields.<refId>` / `orderLine.customFields.<refId>`). The *values* ride along with the records the export already fetches, but the *definitions* — field names and select-option labels — have to be read from mod-orders-storage's `GET /custom-fields`, and that call is made
by mod-data-export-worker under the data-export system user.

## Approach

- Added `orders-storage.custom-fields.collection.get` to `src/main/resources/permissions/system-user-permissions.csv`, alongside the existing `orders-storage.*` reads the orders export already relies on.
- Mirrored it in `descriptors/ModuleDescriptor-template.json` in all four places the same orders-storage read set is listed:
  - `modulePermissions` of `POST /data-export-spring/jobs`
  - `modulePermissions` of `POST /data-export-spring/jobs/send`
  - `subPermissions` of `data-export.edifact.orders.create`
  - the `metadata.user.permissions` system-user set
- Bumped the `folio-export-common` submodule to pick up the `customFields` map on the `purchase_order`, `composite_purchase_order` and `po_line` schemas.